### PR TITLE
Avoid termination due to unhandled exception when parsing invalid arguments to after(...), older(...), thresh(...) and thresh_m(...)

### DIFF
--- a/bitcoin/script/miniscript.h
+++ b/bitcoin/script/miniscript.h
@@ -953,11 +953,17 @@ inline NodeRef<Key> Parse(Span<const char>& in, const Ctx& ctx) {
         if (hash.size() != 20) return {};
         return MakeNodeRef<Key>(NodeType::HASH160, std::move(hash));
     } else if (Func("after", expr)) {
-        unsigned long num = std::stoul(std::string(expr.begin(), expr.end()));
+        uint64_t num;
+        if (!ParseUInt64(std::string(expr.begin(), expr.end()), &num)) {
+            return {};
+        }
         if (num < 1 || num >= 0x80000000UL) return {};
         return MakeNodeRef<Key>(NodeType::AFTER, num);
     } else if (Func("older", expr)) {
-        unsigned long num = std::stoul(std::string(expr.begin(), expr.end()));
+        uint64_t num;
+        if (!ParseUInt64(std::string(expr.begin(), expr.end()), &num)) {
+            return {};
+        }
         if (num < 1 || num >= 0x80000000UL) return {};
         return MakeNodeRef<Key>(NodeType::OLDER, num);
     } else if (Func("and_n", expr)) {
@@ -976,7 +982,10 @@ inline NodeRef<Key> Parse(Span<const char>& in, const Ctx& ctx) {
         return MakeNodeRef<Key>(NodeType::ANDOR, Vector(std::move(left), std::move(mid), std::move(right)));
     } else if (Func("thresh_m", expr)) {
         auto arg = Expr(expr);
-        uint32_t count = std::stoul(std::string(arg.begin(), arg.end()));
+        uint32_t count;
+        if (!ParseUInt32(std::string(arg.begin(), arg.end()), &count)) {
+            return {};
+        }
         std::vector<Key> keys;
         while (expr.size()) {
             if (!Const(",", expr)) return {};
@@ -990,7 +999,10 @@ inline NodeRef<Key> Parse(Span<const char>& in, const Ctx& ctx) {
         return MakeNodeRef<Key>(NodeType::THRESH_M, std::move(keys), count);
     } else if (Func("thresh", expr)) {
         auto arg = Expr(expr);
-        uint32_t count = std::stoul(std::string(arg.begin(), arg.end()));
+        uint32_t count;
+        if (!ParseUInt32(std::string(arg.begin(), arg.end()), &count)) {
+            return {};
+        }
         std::vector<NodeRef<Key>> subs;
         while (expr.size()) {
             if (!Const(",", expr)) return {};


### PR DESCRIPTION
Hi sipa!

Thanks for your excellent work on miniscript and this C++ implementation!

This is really important work so I decided to put some time into breaking it :-)

That has proven quite hard: the implementation seems to be very robust and well-written. I really like the modern C++ style.

Anyways, this is a small issue I found:

Before:

```
$ ./miniscript <<< "after(1)"
      0 scriptlen=2 maxops=1 type=B safe=no nonmal=yes dissat=no input=0 output=nonzero miniscript=after(1)
$ ./miniscript <<< "after(100000000000000000000)"
terminate called after throwing an instance of 'std::out_of_range'
  what():  stoul
Aborted
$ ./miniscript <<< "after()"
terminate called after throwing an instance of 'std::invalid_argument'
  what():  stoul
Aborted
$ for FUNC in after older thresh thresh_m; do
    for N in "" "100000000000000000000"; do
      MINISCRIPT="${FUNC}(${N})"
      echo "Testing miniscript: ${MINISCRIPT}"
      ./miniscript <<< "${MINISCRIPT}"
      echo
    done
  done
Testing miniscript: after()
terminate called after throwing an instance of 'std::invalid_argument'
  what():  stoul
Aborted

Testing miniscript: after(100000000000000000000)
terminate called after throwing an instance of 'std::out_of_range'
  what():  stoul
Aborted

Testing miniscript: older()
terminate called after throwing an instance of 'std::invalid_argument'
  what():  stoul
Aborted

Testing miniscript: older(100000000000000000000)
terminate called after throwing an instance of 'std::out_of_range'
  what():  stoul
Aborted

Testing miniscript: thresh()
terminate called after throwing an instance of 'std::invalid_argument'
  what():  stoul
Aborted

Testing miniscript: thresh(100000000000000000000)
terminate called after throwing an instance of 'std::out_of_range'
  what():  stoul
Aborted

Testing miniscript: thresh_m()
terminate called after throwing an instance of 'std::invalid_argument'
  what():  stoul
Aborted

Testing miniscript: thresh_m(100000000000000000000)
terminate called after throwing an instance of 'std::out_of_range'
  what():  stoul
Aborted

```

After:

```
$ ./miniscript <<< "after(1)"
      0 scriptlen=2 maxops=1 type=B safe=no nonmal=yes dissat=no input=0 output=nonzero miniscript=after(1)
$ ./miniscript <<< "after(100000000000000000000)"
Failed to parse as policy or miniscript 'after(100000000000000000000)'
$ ./miniscript <<< "after()"
Failed to parse as policy or miniscript 'after()'
$ for FUNC in after older thresh thresh_m; do
    for N in "" "100000000000000000000"; do
      MINISCRIPT="${FUNC}(${N})"
      echo "Testing miniscript: ${MINISCRIPT}"
      ./miniscript <<< "${MINISCRIPT}"
      echo
    done
  done
Testing miniscript: after()
Failed to parse as policy or miniscript 'after()'

Testing miniscript: after(100000000000000000000)
Failed to parse as policy or miniscript 'after(100000000000000000000)'

Testing miniscript: older()
Failed to parse as policy or miniscript 'older()'

Testing miniscript: older(100000000000000000000)
Failed to parse as policy or miniscript 'older(100000000000000000000)'

Testing miniscript: thresh()
Failed to parse as policy or miniscript 'thresh()'

Testing miniscript: thresh(100000000000000000000)
Failed to parse as policy or miniscript 'thresh(100000000000000000000)'

Testing miniscript: thresh_m()
Failed to parse as policy or miniscript 'thresh_m()'

Testing miniscript: thresh_m(100000000000000000000)
Failed to parse as policy or miniscript 'thresh_m(100000000000000000000)'

```