### PR TITLE
Avoid heap out-of-bounds read in Node::CalcOps (test case: OP_0 OP_2 OP_EQUAL) and assertion failure in ComputeType (test case: OP_0 OP_0 OP_EQUAL)

### DIFF
--- a/bitcoin/script/miniscript.h
+++ b/bitcoin/script/miniscript.h
@@ -1137,6 +1137,9 @@ inline NodeRef<Key> DecodeSingle(I& in, I last, const Ctx& ctx) {
     }
     subs.clear();
     if (last - in >= 3 && in[0].first == OP_EQUAL && ParseScriptNumber(in[1], k)) {
+        if (k < 2) {
+            return {};
+        }
         in += 2;
         while (last - in >= 2 && in[0].first == OP_ADD) {
             ++in;
@@ -1147,6 +1150,9 @@ inline NodeRef<Key> DecodeSingle(I& in, I last, const Ctx& ctx) {
         auto sub = DecodeSingle<Key>(in, last, ctx);
         if (!sub) return {};
         subs.push_back(std::move(sub));
+        if (k >= subs.size()) {
+            return {};
+        }
         std::reverse(subs.begin(), subs.end());
         return MakeNodeRef<Key>(NodeType::THRESH, std::move(subs), k);
     }

--- a/bitcoin/script/miniscript.h
+++ b/bitcoin/script/miniscript.h
@@ -506,6 +506,7 @@ private:
                     next_sats.push_back(sats[sats.size() - 1] + sub->ops.sat);
                     sats = std::move(next_sats);
                 }
+                assert(k < sats.size());
                 return {stat, sats[k], sats[0]};
             }
         }
@@ -548,6 +549,7 @@ private:
                     next_sats.push_back(sats[sats.size() - 1] + sub->ss.sat);
                     sats = std::move(next_sats);
                 }
+                assert(k < sats.size());
                 return {sats[k], sats[0]};
             }
         }
@@ -614,6 +616,7 @@ private:
                 }
                 InputStack nsat = ZERO;
                 for (size_t i = 0; i < k; ++i) nsat = std::move(nsat) + ZERO;
+                assert(k < sats.size());
                 return InputResult(std::move(nsat), std::move(sats[k]));
             }
             case NodeType::THRESH: {
@@ -630,6 +633,7 @@ private:
                 for (size_t i = 0; i < sats.size(); ++i) {
                     if (i != k) nsat = Choose(std::move(nsat), std::move(sats[i]), nonmal);
                 }
+                assert(k < sats.size());
                 return InputResult(std::move(nsat), std::move(sats[k]));
             }
             case NodeType::OLDER: {


### PR DESCRIPTION
Avoid heap out-of-bounds read in `Node::CalcOps` (test case: `OP_0 OP_2 OP_EQUAL`) and assertion failure in `ComputeType` (test case: `OP_0 OP_0 OP_EQUAL`).