### PR TITLE
Update Makefile - lack of -std=c++11 flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ HEADERS := bitcoin/util/vector.h bitcoin/util/strencodings.h bitcoin/span.h bitc
 SOURCES := bitcoin/util/strencodings.cpp bitcoin/util/spanparsing.cpp bitcoin/script/script.cpp bitcoin/script/miniscript.cpp compiler.cpp
 
 miniscript: $(HEADERS) $(SOURCES) main.cpp
-	g++ -O3 -g0 -Wall -march=native -flto -Ibitcoin $(SOURCES) main.cpp -o miniscript
+	g++ -O3 -g0 -Wall -std=c++11 -march=native -flto -Ibitcoin $(SOURCES) main.cpp -o miniscript
 
 miniscript.js: $(HEADERS) $(SOURCES) js_bindings.cpp
 	em++ -O3 -g0 -Wall -std=c++11 -fno-rtti -flto -Ibitcoin $(SOURCES) js_bindings.cpp -s WASM=1 -s FILESYSTEM=0 -s ENVIRONMENT=web -s DISABLE_EXCEPTION_CATCHING=0 -s EXPORTED_FUNCTIONS='["_miniscript_compile","_miniscript_analyze","_malloc","_free"]' -s EXTRA_EXPORTED_RUNTIME_METHODS='["cwrap","UTF8ToString"]' -o miniscript.js


### PR DESCRIPTION
Lack of -std=c++11 caused a long list of errors with the following at the begining:

error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
 #error This file requires compiler and library support \