### PR TITLE
use CompilerContext::Key instead of std::string where appropriate

### DIFF
--- a/compiler.h
+++ b/compiler.h
@@ -38,7 +38,7 @@ struct CompilerContext {
 
 extern const CompilerContext COMPILER_CTX;
 
-bool Compile(const std::string& policy, miniscript::NodeRef<std::string>& ret, double& avgcost);
+bool Compile(const std::string& policy, miniscript::NodeRef<CompilerContext::Key>& ret, double& avgcost);
 
 std::string Expand(std::string str);
 std::string Abbreviate(std::string str);


### PR DESCRIPTION
Switching out the `Key` type will result in a bunch of errors due to use of `std::string`.

It may be cleaner looking to typedef again outside of `CompilerContext`, but it's probably fine as is.