### PR TITLE
Miniscript language updates

### DIFF
--- a/bitcoin/script/miniscript.cpp
+++ b/bitcoin/script/miniscript.cpp
@@ -45,7 +45,7 @@ Type ComputeType(NodeType nodetype, Type x, Type y, Type z, const std::vector<Ty
     // Sanity check on k
     if (nodetype == NodeType::OLDER || nodetype == NodeType::AFTER) {
         assert(k >= 1 && k < 0x80000000UL);
-    } else if (nodetype == NodeType::THRESH_M) {
+    } else if (nodetype == NodeType::MULTI) {
         assert(k >= 1 && k <= n_keys);
     } else if (nodetype == NodeType::THRESH) {
         assert(k > 1 && k < n_subs);
@@ -66,9 +66,9 @@ Type ComputeType(NodeType nodetype, Type x, Type y, Type z, const std::vector<Ty
         assert(n_subs == 0);
     }
     // Sanity check on keys
-    if (nodetype == NodeType::PK || nodetype == NodeType::PK_H) {
+    if (nodetype == NodeType::PK_K || nodetype == NodeType::PK_H) {
         assert(n_keys == 1);
-    } else if (nodetype == NodeType::THRESH_M) {
+    } else if (nodetype == NodeType::MULTI) {
         assert(n_keys >= 1 && n_keys <= 20);
     } else {
         assert(n_keys == 0);
@@ -78,7 +78,7 @@ Type ComputeType(NodeType nodetype, Type x, Type y, Type z, const std::vector<Ty
     // It heavily relies on Type's << operator (where "X << a_mst" means
     // "X has all properties listed in a").
     switch (nodetype) {
-        case NodeType::PK: return "Konudemsx"_mst;
+        case NodeType::PK_K: return "Konudemsx"_mst;
         case NodeType::PK_H: return "Knudemsx"_mst;
         case NodeType::OLDER: return "Bzfmx"_mst;
         case NodeType::AFTER: return "Bzfmx"_mst;
@@ -171,7 +171,7 @@ Type ComputeType(NodeType nodetype, Type x, Type y, Type z, const std::vector<Ty
             (x & y & z & "m"_mst).If(x << "e"_mst && (x | y | z) << "s"_mst) | // m=m_x*m_y*m_z*e_x*(s_x+s_y+s_z)
             (z & (x | y) & "s"_mst) | // s=s_z*(s_x+s_y)
             "x"_mst; // x
-        case NodeType::THRESH_M: return "Bnudems"_mst;
+        case NodeType::MULTI: return "Bnudems"_mst;
         case NodeType::THRESH: {
             bool all_e = true;
             bool all_m = true;
@@ -199,7 +199,7 @@ Type ComputeType(NodeType nodetype, Type x, Type y, Type z, const std::vector<Ty
 
 size_t ComputeScriptLen(NodeType nodetype, Type sub0typ, size_t subsize, uint32_t k, size_t n_subs, size_t n_keys) {
     switch (nodetype) {
-        case NodeType::PK: return subsize + 34;
+        case NodeType::PK_K: return subsize + 34;
         case NodeType::PK_H: return subsize + 3 + 21;
         case NodeType::OLDER: return subsize + 1 + (CScript() << k).size();
         case NodeType::AFTER: return subsize + 1 + (CScript() << k).size();
@@ -224,7 +224,7 @@ size_t ComputeScriptLen(NodeType nodetype, Type sub0typ, size_t subsize, uint32_
         case NodeType::OR_I: return subsize + 3;
         case NodeType::ANDOR: return subsize + 3;
         case NodeType::THRESH: return subsize + n_subs + 1;
-        case NodeType::THRESH_M: return subsize + 3 + (n_keys > 16) + (k > 16) + 34 * n_keys;
+        case NodeType::MULTI: return subsize + 3 + (n_keys > 16) + (k > 16) + 34 * n_keys;
     }
     assert(false);
     return 0;

--- a/bitcoin/script/miniscript.h
+++ b/bitcoin/script/miniscript.h
@@ -42,7 +42,7 @@ namespace miniscript {
  *   - This is obtained by adding an OP_VERIFY to a B, modifying the last opcode
  *     of a B to its -VERIFY version (only for OP_CHECKSIG, OP_CHECKSIGVERIFY
  *     and OP_EQUAL), or using IFs where both branches are also Vs.
- *   - For example vc:pk(key) = <key> OP_CHECKSIGVERIFY
+ *   - For example vc:pk_k(key) = <key> OP_CHECKSIGVERIFY
  * - "K" Key:
  *   - Takes its inputs from the top of the stack.
  *   - Becomes a B when followed by OP_CHECKSIG.
@@ -54,7 +54,7 @@ namespace miniscript {
  *   - When satisfied, pushes a nonzero value (like B) on top of the stack, or one below.
  *   - When dissatisfied, pushes 0 op top of the stack or one below.
  *   - Is always "OP_SWAP [B]" or "OP_TOALTSTACK [B] OP_FROMALTSTACK".
- *   - For example sc:pk(key) = OP_SWAP <key> OP_CHECKSIG
+ *   - For example sc:pk_k(key) = OP_SWAP <key> OP_CHECKSIG
  *
  * There a type properties that help reasoning about correctness:
  * - "z" Zero-arg:
@@ -163,7 +163,7 @@ NodeRef<Key> MakeNodeRef(Args&&... args) { return std::make_shared<const Node<Ke
 enum class NodeType {
     JUST_0,    //!< OP_0
     JUST_1,    //!< OP_1
-    PK,        //!< [key]
+    PK_K,      //!< [key]
     PK_H,      //!< OP_DUP OP_HASH160 [keyhash] OP_EQUALVERIFY
     OLDER,     //!< [n] OP_CHECKSEQUENCEVERIFY
     AFTER,     //!< [n] OP_CHECKLOCKTIMEVERIFY
@@ -186,7 +186,7 @@ enum class NodeType {
     OR_I,      //!< OP_IF [X] OP_ELSE [Y] OP_ENDIF
     ANDOR,     //!< [X] OP_NOTIF [Z] OP_ELSE [Y] OP_ENDIF
     THRESH,    //!< [X1] ([Xn] OP_ADD)* [k] OP_EQUAL
-    THRESH_M,  //!< [k] [key_n]* [n] OP_CHECKMULTISIG
+    MULTI,     //!< [k] [key_n]* [n] OP_CHECKMULTISIG
     // AND_N(X,Y) is represented as ANDOR(X,Y,0)
     // WRAP_T(X) is represented as AND_V(X,1)
     // WRAP_L(X) is represented as OR_I(0,X)
@@ -302,7 +302,7 @@ struct Node {
     const NodeType nodetype;
     //! The k parameter (time for OLDER/AFTER, threshold for THRESH(_M))
     const uint32_t k = 0;
-    //! The keys used by this expression (only for PK/PK_H/THRESH_M)
+    //! The keys used by this expression (only for PK_K/PK_H/MULTI)
     const std::vector<Key> keys;
     //! The data bytes in this expression (only for HASH160/HASH256/SHA256/RIPEMD10).
     const std::vector<unsigned char> data;
@@ -351,7 +351,7 @@ private:
     CScript MakeScript(const Ctx& ctx, bool verify = false) const {
         std::vector<unsigned char> bytes;
         switch (nodetype) {
-            case NodeType::PK: return CScript() << ctx.ToPKBytes(keys[0]);
+            case NodeType::PK_K: return CScript() << ctx.ToPKBytes(keys[0]);
             case NodeType::PK_H: return CScript() << OP_DUP << OP_HASH160 << ctx.ToPKHBytes(keys[0]) << OP_EQUALVERIFY;
             case NodeType::OLDER: return CScript() << k << OP_CHECKSEQUENCEVERIFY;
             case NodeType::AFTER: return CScript() << k << OP_CHECKLOCKTIMEVERIFY;
@@ -375,7 +375,7 @@ private:
             case NodeType::OR_C: return subs[0]->MakeScript(ctx) + (CScript() << OP_NOTIF) + subs[1]->MakeScript(ctx) + (CScript() << OP_ENDIF);
             case NodeType::OR_I: return (CScript() << OP_IF) + subs[0]->MakeScript(ctx) + (CScript() << OP_ELSE) + subs[1]->MakeScript(ctx) + (CScript() << OP_ENDIF);
             case NodeType::ANDOR: return subs[0]->MakeScript(ctx) + (CScript() << OP_NOTIF) + subs[2]->MakeScript(ctx) + (CScript() << OP_ELSE) + subs[1]->MakeScript(ctx) + (CScript() << OP_ENDIF);
-            case NodeType::THRESH_M: {
+            case NodeType::MULTI: {
                 CScript script = CScript() << k;
                 for (const auto& key : keys) {
                     script << ctx.ToPKBytes(key);
@@ -420,10 +420,10 @@ private:
         std::string ret = wrapped ? ":" : "";
 
         switch (nodetype) {
-            case NodeType::PK: {
+            case NodeType::PK_K: {
                 std::string key_str;
                 success = ctx.ToString(keys[0], key_str);
-                return std::move(ret) + "pk(" + std::move(key_str) + ")";
+                return std::move(ret) + "pk_k(" + std::move(key_str) + ")";
             }
             case NodeType::PK_H: {
                 std::string key_str;
@@ -448,8 +448,8 @@ private:
                 // and_n(X,Y) is syntactic sugar for andor(X,Y,0).
                 if (subs[2]->nodetype == NodeType::JUST_0) return std::move(ret) + "and_n(" + subs[0]->MakeString(ctx, success) + "," + subs[1]->MakeString(ctx, success) + ")";
                 return std::move(ret) + "andor(" + subs[0]->MakeString(ctx, success) + "," + subs[1]->MakeString(ctx, success) + "," + subs[2]->MakeString(ctx, success) + ")";
-            case NodeType::THRESH_M: {
-                auto str = std::move(ret) + "thresh_m(" + std::to_string(k);
+            case NodeType::MULTI: {
+                auto str = std::move(ret) + "multi(" + std::to_string(k);
                 for (const auto& key : keys) {
                     std::string key_str;
                     success &= ctx.ToString(key, key_str);
@@ -471,7 +471,7 @@ private:
 
     internal::Ops CalcOps() const {
         switch (nodetype) {
-            case NodeType::PK: return {0, 0, 0};
+            case NodeType::PK_K: return {0, 0, 0};
             case NodeType::PK_H: return {3, 0, 0};
             case NodeType::OLDER: return {1, 0, {}};
             case NodeType::AFTER: return {1, 0, {}};
@@ -486,7 +486,7 @@ private:
             case NodeType::OR_C: return {2 + subs[0]->ops.stat + subs[1]->ops.stat, Choose(subs[0]->ops.sat, subs[1]->ops.sat + subs[0]->ops.dsat), {}};
             case NodeType::OR_I: return {3 + subs[0]->ops.stat + subs[1]->ops.stat, Choose(subs[0]->ops.sat, subs[1]->ops.sat), Choose(subs[0]->ops.dsat, subs[1]->ops.dsat)};
             case NodeType::ANDOR: return {3 + subs[0]->ops.stat + subs[1]->ops.stat + subs[2]->ops.stat, Choose(subs[1]->ops.sat + subs[0]->ops.sat, subs[0]->ops.dsat + subs[2]->ops.sat), subs[0]->ops.dsat + subs[2]->ops.dsat};
-            case NodeType::THRESH_M: return {1, (uint32_t)keys.size(), (uint32_t)keys.size()};
+            case NodeType::MULTI: return {1, (uint32_t)keys.size(), (uint32_t)keys.size()};
             case NodeType::WRAP_A: return {2 + subs[0]->ops.stat, subs[0]->ops.sat, subs[0]->ops.dsat};
             case NodeType::WRAP_S: return {1 + subs[0]->ops.stat, subs[0]->ops.sat, subs[0]->ops.dsat};
             case NodeType::WRAP_C: return {1 + subs[0]->ops.stat, subs[0]->ops.sat, subs[0]->ops.dsat};
@@ -515,7 +515,7 @@ private:
 
     internal::StackSize CalcStackSize() const {
         switch (nodetype) {
-            case NodeType::PK: return {1, 1};
+            case NodeType::PK_K: return {1, 1};
             case NodeType::PK_H: return {2, 2};
             case NodeType::OLDER: return {0, {}};
             case NodeType::AFTER: return {0, {}};
@@ -530,7 +530,7 @@ private:
             case NodeType::OR_C: return {Choose(subs[0]->ss.sat, subs[0]->ss.dsat + subs[1]->ss.sat), {}};
             case NodeType::OR_D: return {Choose(subs[0]->ss.sat, subs[0]->ss.dsat + subs[1]->ss.sat), subs[0]->ss.dsat + subs[1]->ss.dsat};
             case NodeType::OR_I: return {Choose(subs[0]->ss.sat + 1, subs[1]->ss.sat + 1), Choose(subs[0]->ss.dsat + 1, subs[1]->ss.dsat + 1)};
-            case NodeType::THRESH_M: return {(uint32_t)keys.size() + 1, (uint32_t)keys.size() + 1};
+            case NodeType::MULTI: return {(uint32_t)keys.size() + 1, (uint32_t)keys.size() + 1};
             case NodeType::WRAP_A: return subs[0]->ss;
             case NodeType::WRAP_S: return subs[0]->ss;
             case NodeType::WRAP_C: return subs[0]->ss;
@@ -590,7 +590,7 @@ private:
         const auto INVALID = InputStack().Available(Availability::NO);
 
         switch (nodetype) {
-            case NodeType::PK: {
+            case NodeType::PK_K: {
                 std::vector<unsigned char> sig;
                 Availability avail = ctx.Sign(keys[0], sig);
                 return InputResult(ZERO, InputStack(std::move(sig)).WithSig().Available(avail));
@@ -600,7 +600,7 @@ private:
                 Availability avail = ctx.Sign(keys[0], sig);
                 return InputResult(ZERO + InputStack(key), (InputStack(std::move(sig)).WithSig() + InputStack(key)).Available(avail));
             }
-            case NodeType::THRESH_M: {
+            case NodeType::MULTI: {
                 std::vector<InputStack> sats = Vector(ZERO);
                 for (size_t i = 0; i < keys.size(); ++i) {
                     std::vector<unsigned char> sig;
@@ -853,10 +853,10 @@ inline NodeRef<Key> Parse(Span<const char>& in, const Ctx& ctx, int recursion_de
         return MakeNodeRef<Key>(NodeType::JUST_0);
     } else if (expr == Span<const char>("1", 1)) {
         return MakeNodeRef<Key>(NodeType::JUST_1);
-    } else if (Func("pk", expr)) {
+    } else if (Func("pk_k", expr)) {
         Key key;
         if (ctx.FromString(expr.begin(), expr.end(), key)) {
-            return MakeNodeRef<Key>(NodeType::PK, Vector(std::move(key)));
+            return MakeNodeRef<Key>(NodeType::PK_K, Vector(std::move(key)));
         }
         return {};
     } else if (Func("pk_h", expr)) {
@@ -909,7 +909,7 @@ inline NodeRef<Key> Parse(Span<const char>& in, const Ctx& ctx, int recursion_de
         auto right = Parse<Key>(expr, ctx, recursion_depth + 1);
         if (!right || expr.size()) return {};
         return MakeNodeRef<Key>(NodeType::ANDOR, Vector(std::move(left), std::move(mid), std::move(right)));
-    } else if (Func("thresh_m", expr)) {
+    } else if (Func("multi", expr)) {
         auto arg = Expr(expr);
         int64_t count;
         if (!ParseInt64(std::string(arg.begin(), arg.end()), &count)) return {};
@@ -923,7 +923,7 @@ inline NodeRef<Key> Parse(Span<const char>& in, const Ctx& ctx, int recursion_de
         }
         if (keys.size() < 1 || keys.size() > 20) return {};
         if (count < 1 || count > (int64_t)keys.size()) return {};
-        return MakeNodeRef<Key>(NodeType::THRESH_M, std::move(keys), count);
+        return MakeNodeRef<Key>(NodeType::MULTI, std::move(keys), count);
     } else if (Func("thresh", expr)) {
         auto arg = Expr(expr);
         int64_t count;
@@ -995,7 +995,7 @@ inline NodeRef<Key> DecodeSingle(I& in, I last, const Ctx& ctx) {
         Key key;
         if (!ctx.FromPKBytes(in[0].second.begin(), in[0].second.end(), key)) return {};
         ++in;
-        return MakeNodeRef<Key>(NodeType::PK, Vector(std::move(key)));
+        return MakeNodeRef<Key>(NodeType::PK_K, Vector(std::move(key)));
     }
     if (last - in >= 5 && in[0].first == OP_VERIFY && in[1].first == OP_EQUAL && in[3].first == OP_HASH160 && in[4].first == OP_DUP && in[2].second.size() == 20) {
         Key key;
@@ -1133,7 +1133,7 @@ inline NodeRef<Key> DecodeSingle(I& in, I last, const Ctx& ctx) {
         if (k < 1 || k > n) return {};
         in += 3 + n;
         std::reverse(keys.begin(), keys.end());
-        return MakeNodeRef<Key>(NodeType::THRESH_M, std::move(keys), k);
+        return MakeNodeRef<Key>(NodeType::MULTI, std::move(keys), k);
     }
     subs.clear();
     if (last - in >= 3 && in[0].first == OP_EQUAL && ParseScriptNumber(in[1], k)) {

--- a/bitcoin/script/miniscript.h
+++ b/bitcoin/script/miniscript.h
@@ -409,6 +409,12 @@ private:
                     success = ctx.ToString(subs[0]->keys[0], key_str);
                     return std::move(ret) + "pk(" + std::move(key_str) + ")";
                 }
+                if (subs[0]->nodetype == NodeType::PK_H) {
+                    // pkh(K) is syntactix sugar for c:pk_h(K)
+                    std::string key_str;
+                    success = ctx.ToString(subs[0]->keys[0], key_str);
+                    return std::move(ret) + "pkh(" + std::move(key_str) + ")";
+                }
                 return "c" + subs[0]->MakeString(ctx, success, true);
             case NodeType::WRAP_D: return "d" + subs[0]->MakeString(ctx, success, true);
             case NodeType::WRAP_V: return "v" + subs[0]->MakeString(ctx, success, true);
@@ -864,6 +870,12 @@ inline NodeRef<Key> Parse(Span<const char>& in, const Ctx& ctx, int recursion_de
         Key key;
         if (ctx.FromString(expr.begin(), expr.end(), key)) {
             return MakeNodeRef<Key>(NodeType::WRAP_C, Vector(MakeNodeRef<Key>(NodeType::PK_K, Vector(std::move(key)))));
+        }
+        return {};
+    } else if (Func("pkh", expr)) {
+        Key key;
+        if (ctx.FromString(expr.begin(), expr.end(), key)) {
+            return MakeNodeRef<Key>(NodeType::WRAP_C, Vector(MakeNodeRef<Key>(NodeType::PK_H, Vector(std::move(key)))));
         }
         return {};
     } else if (Func("pk_k", expr)) {

--- a/index.html
+++ b/index.html
@@ -165,7 +165,7 @@ Links:<ul>
 <form>
   <div class="form-group">
     <label for="analyze_ms">Miniscript</label>
-    <textarea class="form-control" id="analyze_ms" rows="1">and_v(vc:pk(K),c:pk(A))</textarea>
+    <textarea class="form-control" id="analyze_ms" rows="1">and_v(v:pk(K),pk(A))</textarea>
     <small class="form-text test-muted">Provide a well-typed miniscript expression of type "B".</small>
   </div>
   <button type="button" class="btn btn-primary" onclick="miniscript_analyze();">Analyze</button>
@@ -184,8 +184,8 @@ Links:<ul>
 This table shows all Miniscript <em>fragments</em> and their associated semantics and Bitcoin Script.
 Fragments that do not change the semantics of their subexpressions are called <em>wrappers</em>. Normal fragments use
 a "fragment(arguments,...)" notation, while wrappers are written using prefixes separated from other fragments
-by a colon. The colon is dropped between subsequent wrappers; e.g. <code>vc:pk(key)</code> is the <code>v:</code>
-wrapper applied to the <code>c:</code> wrapper applied to the <code>pk</code> fragment for a given key.
+by a colon. The colon is dropped between subsequent wrappers; e.g. <code>dv:older(144)</code> is the <code>d:</code>
+wrapper applied to the <code>v:</code> wrapper applied to the <code>older</code> fragment for 144 blocks.
 
 <div class="table-responsive">
 <table class="table table-sm">
@@ -203,13 +203,21 @@ wrapper applied to the <code>c:</code> wrapper applied to the <code>pk</code> fr
   <td><samp>1</samp></td>
 </tr>
 <tr>
-  <td rowspan="2">check(key)</td>
-  <td><code>pk(key)</code></td>
+  <td rowspan="4">check(key)</td>
+  <td><code>pk_k(key)</code></td>
   <td><samp>&lt;key&gt;</samp></td>
 </tr>
 <tr>
   <td><code>pk_h(key)</code></td>
   <td><samp>DUP HASH160 &lt;HASH160(key)&gt; EQUALVERIFY</samp></td>
+</tr>
+<tr>
+  <td><code>pk(key) = c:pk_k(key)</code></td>
+  <td><samp>&lt;key&gt; CHECKSIG</samp></td>
+</tr>
+<tr>
+  <td><code>pkh(key) = c:pk_h(key)</code></td>
+  <td><samp>DUP HASH160 &lt;HASH160(key)&gt; EQUALVERIFY CHECKSIG</samp></td>
 </tr>
 <tr>
   <td>nSequence &ge; n (and compatible)</td>
@@ -282,7 +290,7 @@ wrapper applied to the <code>c:</code> wrapper applied to the <code>pk</code> fr
 </tr>
 <tr>
   <td>check(key<sub>1</sub>) + ... + check(key<sub>n</sub>) = k</td>
-  <td><code>thresh_m(k,key<sub>1</sub>,...,key<sub>n</sub>)</code></td>
+  <td><code>multi(k,key<sub>1</sub>,...,key<sub>n</sub>)</code></td>
   <td><samp>&lt;k&gt; &lt;key<sub>1</sub>&gt; ... &lt;key<sub>n</sub>&gt; &lt;n&gt; CHECKMULTISIG</samp></td>
 </tr>
 <tr>
@@ -328,7 +336,7 @@ wrapper applied to the <code>c:</code> wrapper applied to the <code>pk</code> fr
 </tbody>
 </table>
 </div>
-The <code>and_n</code> fragment and <code>t:</code>, <code>l:</code>, and <code>u:</code> wrappers are syntactic sugar for other Miniscripts, as listed in the table above.
+The <code>pk</code>, <code>pkh</code>, and <code>and_n</code> fragments and <code>t:</code>, <code>l:</code>, and <code>u:</code> wrappers are syntactic sugar for other Miniscripts, as listed in the table above.
 In what follows, they will not be included anymore, as their properties can be derived by looking at their expansion.
 
 <p>
@@ -348,14 +356,14 @@ When dissatisfied, they push an exact 0 onto the stack (if dissatisfaction witho
 This type is used for most expressions, and required for the top level expression. An example is <code>older(n)</code> = <samp>&lt;n&gt; CHECKSEQUENCEVERIFY</samp>.</li>
 <li><b>"V"</b> Verify expressions. Like "B", these take their inputs from the top of the stack. Upon satisfaction however, they continue without pushing anything. They cannot be
 dissatisfied without aborting. A "V" can be obtained using the <code>v:</code> wrapper on a "B" expression, or by combining other "V" expressions using <code>and_v</code>, <code>or_i</code>, <code>or_c</code>, or <code>andor</code>.
-An example is <code>vc:pk(key)</code> = <samp>&lt;key&gt; CHECKSIGVERIFY</samp>.</li>
+An example is <code>v:pk(key)</code> = <samp>&lt;key&gt; CHECKSIGVERIFY</samp>.</li>
 <li><b>"K"</b> Key expressions. They again take their inputs from the top of the stack, but instead of verifying a condition directly they always push a public key onto the stack, for
 which a signature is still required to satisfy the expression. A "K" can be converted into a "B" using the <code>c:</code> wrapper (<samp>CHECKSIG</samp>).
 An example is <code>pk_h(key)</code> = <samp>DUP HASH160 &lt;Hash160(key)&gt; EQUALVERIFY</samp></li>
 <li><b>"W"</b> Wrapped expressions. They take their inputs from one below the top of the stack, and push a nonzero (in case of satisfaction) or zero (in case of dissatisfaction)
 either on top of the stack, or one below. So for example a 3-input "W" would take the stack "A B C D E F" and turn it into "A B F 0" or "A B 0 F" in case of dissatisfaction, and
 "A B F n" or "A B n F" in case of satisfaction (with n a nonzero value). Every "W" is either <code>s:B</code> (<samp>SWAP B</samp>) or <code>a:B</code> (<samp>TOALTSTACK B FROMALTSTACK</samp>).
-An example is <code>sc:pk(key)</code> = <samp>SWAP &lt;key&gt; CHECKSIG</samp>.</li>
+An example is <code>s:pk(key)</code> = <samp>SWAP &lt;key&gt; CHECKSIG</samp>.</li>
 </ul>
 
 <p>
@@ -375,7 +383,7 @@ This tables lists the correctness requirements for each of the Miniscript expres
 <tbody>
 <tr><td><code>0</code></td><td></td><td>B</td><td>z; u; d</td></tr>
 <tr><td><code>1</code></td><td></td><td>B</td><td>z; u</td></tr>
-<tr><td><code>pk(key)</code></td><td></td><td>K</td><td>o; n; d; u</td></tr>
+<tr><td><code>pk_k(key)</code></td><td></td><td>K</td><td>o; n; d; u</td></tr>
 <tr><td><code>pk_h(key)</code></td><td></td><td>K</td><td>n; d; u</td></tr>
 <tr><td><code>older(n)</code>, <code>after(n)</code></td><td>1 &le; n &lt; 2<sup>31</sup></td><td>B</td><td>z</td></tr>
 <tr><td><code>sha256(h)</code></td><td></td><td>B</td><td>o; n; d; u</td></tr>
@@ -390,7 +398,7 @@ This tables lists the correctness requirements for each of the Miniscript expres
 <tr><td><code>or_d(<em>X</em>,<em>Z</em>)</code></td><td><em>X</em> is Bdu; <em>Z</em> is B</td><td>B</td><td>z=z<sub>X</sub>z<sub>Z</sub>; o=o<sub>X</sub>z<sub>Z</sub>; d=d<sub>Z</sub>; u=u<sub>Z</sub></td></tr>
 <tr><td><code>or_i(<em>X</em>,<em>Z</em>)</code></td><td>both are B, K, or V</td><td>same as X/Z</td><td>o=z<sub>X</sub>z<sub>Z</sub>; u=u<sub>X</sub>u<sub>Z</sub>; d=d<sub>X</sub> or d<sub>Z</sub></td></tr>
 <tr><td><code>thresh(k,<em>X<sub>1</sub></em>,...,<em>X<sub>n</sub></em>)</code></td><td>1 &lt; k &lt; n; <em>X<sub>1</sub></em> is Bdu; others are Wdu</td><td>B</td><td>z=all are z; o=all are z except one is o; d; u</td></tr>
-<tr><td><code>thresh_m(k,key<sub>1</sub>,...,key<sub>n</sub>)</code></td><td>1 &le; k &le; n</td><td>B</td><td>n; d; u</td></tr>
+<tr><td><code>multi(k,key<sub>1</sub>,...,key<sub>n</sub>)</code></td><td>1 &le; k &le; n</td><td>B</td><td>n; d; u</td></tr>
 <tr><td><code>a:X</code></td><td><em>X</em> is B</td><td>W</td><td>d=d<sub>X</sub>; u=u<sub>X</sub></td></tr>
 <tr><td><code>s:X</code></td><td><em>X</em> is Bo</td><td>W</td><td>d=d<sub>X</sub>; u=u<sub>X</sub></td></tr>
 <tr><td><code>c:X</code></td><td><em>X</em> is K</td><td>B</td><td>o=o<sub>X</sub>; n=n<sub>X</sub>; d=d<sub>X</sub>; u</td></tr>
@@ -409,14 +417,14 @@ This tables lists the correctness requirements for each of the Miniscript expres
 Various types of Bitcoin Scripts have different resource limitations, either through consensus or standardness. Some of them affect otherwise valid Miniscripts: <ul>
 <li>Scripts over 10000 bytes are invalid by consensus (bare, P2SH, P2WSH, P2SH-P2WSH).</li>
 <li>Scripts over 520 bytes are invalid by consensus (P2SH).</li>
-<li>Script satisfactions where the total number of non-push opcodes plus the number of keys participating in all executed <code>thresh_m</code>s, is above 201, are invalid by consensus (bare, P2SH, P2WSH, P2SH-P2WSH).</li>
-<li>Anything but <code>c:pk(key)</code> (P2PK), <code>c:pk_h(key)</code> (P2PKH), and <code>thresh_m(k,...)</code> up to n=3 is invalid by standardness (bare).</li>
+<li>Script satisfactions where the total number of non-push opcodes plus the number of keys participating in all executed <code>multi</code>s, is above 201, are invalid by consensus (bare, P2SH, P2WSH, P2SH-P2WSH).</li>
+<li>Anything but <code>pk(key)</code> (P2PK), <code>pkh(key)</code> (P2PKH), and <code>multi(k,...)</code> up to n=3 is invalid by standardness (bare).</li>
 <li>Scripts over 3600 bytes are invalid by standardness (P2WSH, P2SH-P2WSH).</li>
 <li>Script satisfactions with a serialized <samp>scriptSig</samp> over 1650 bytes are invalid by standardness (P2SH).</li>
 <li>Script satisfactions with a witness consisting of over 100 stack elements (excluding the script itself) are invalid by standardness (P2WSH, P2SH-P2WSH).</li>
 </ul>
 Miniscript makes it easy to verify that the ability to satisfy a script is not impacted by these limits. Note that this is different from verifying whether the limits are never
-reachable at all (which is also possible). Consider for example an <code>or_b(<em>X</em>,<em>Y</em>)</code> where both <em>X</em> and <em>Y</em> require a number of large <code>thresh_m</code>s
+reachable at all (which is also possible). Consider for example an <code>or_b(<em>X</em>,<em>Y</em>)</code> where both <em>X</em> and <em>Y</em> require a number of large <code>multi</code>s
 to be executed to satisfy. It may be the case that satisfying just one of <em>X</em> or <em>Y</em> does not exceed the ops limit, while satisfying both does. As it's never required to
 satisfy both, the limit does not prevent satisfaction.
 
@@ -455,7 +463,7 @@ are listed for completeness, but marked in <span class="text-muted">[grey]</span
 <tbody>
 <tr><td><code>0</code></td><td></td><td>-</td></tr>
 <tr><td><code>1</code></td><td>-</td><td></td></tr>
-<tr><td><code>pk(key)</code></td><td>0</td><td>sig</td></tr>
+<tr><td><code>pk_k(key)</code></td><td>0</td><td>sig</td></tr>
 <tr><td><code>pk_h(key)</code></td><td>0 key</td><td>sig key</td></tr>
 <tr><td><code>older(n)</code></td><td>-</td><td></td></tr>
 <tr><td><code>after(n)</code></td><td>-</td><td></td></tr>
@@ -471,7 +479,7 @@ are listed for completeness, but marked in <span class="text-muted">[grey]</span
 <tr><td><code>or_d(<em>X</em>,<em>Z</em>)</code></td><td>dsat(<em>Z</em>) dsat(<em>X</em>)</td><td>sat(<em>X</em>); sat(<em>Z</em>) dsat(<em>X</em>)</td></tr>
 <tr><td><code>or_i(<em>X</em>,<em>Z</em>)</code></td><td>dsat(<em>X</em>) 1; dsat(<em>Z</em>) 0</td><td>sat(<em>X</em>) 1; sat(<em>Z</em>) 0</td></tr>
 <tr><td><code>thresh(k,<em>X<sub>1</sub></em>,...,<em>X<sub>n</sub></em>)</code></td><td>All dsats <span class="text-muted">[Sats/dsats with 1 &le; #(sats) &ne; k]</span></td><td>Sats/dsats with #(sats) = k</td></tr>
-<tr><td><code>thresh_m(k,key<sub>1</sub>,...,key<sub>n</sub>)</code></td><td>0 0 ... 0 (n+1 times)</td><td>0 sig ... sig</td></tr>
+<tr><td><code>multi(k,key<sub>1</sub>,...,key<sub>n</sub>)</code></td><td>0 0 ... 0 (n+1 times)</td><td>0 sig ... sig</td></tr>
 <tr><td><code>a:<em>X</em></code></td><td>dsat(<em>X</em>)</td><td>sat(<em>X</em>)</td></tr>
 <tr><td><code>s:<em>X</em></code></td><td>dsat(<em>X</em>)</td><td>sat(<em>X</em>)</td></tr>
 <tr><td><code>c:<em>X</em></code></td><td>dsat(<em>X</em>)</td><td>sat(<em>X</em>)</td></tr>
@@ -547,7 +555,7 @@ In order to produce non-malleable satisfactions we make use of a function that r
 <li>Iterate over all the valid satisfactions/dissatisfactions in the table above (including the non-canonical ones), taking into account:<ul>
   <li>The dissatisfactions for <code>sha256</code>, <code>ripemd160</code>, <code>hash256</code>, and <code>hash160</code> are always malleable (reason 1), so instead use DONTUSE there.</li>
   <li>The non-canonical options for <code>and_b</code>, <code>or_b</code>, and <code>thresh</code> are always overcomplete (reason 3), so instead use DONTUSE there as well (with HASSIG flag if the original non-canonical solution had one).
-  <li>The satisfactions for <code>pk</code>, <code>pk_h</code>, and <code>thresh_m</code> can be marked HASSIG.</li>
+  <li>The satisfactions for <code>pk_k</code>, <code>pk_h</code>, and <code>multi</code> can be marked HASSIG.</li>
   <li>When constructing solutions by combining results for subexpressions, the result is DONTUSE if any of the constituent results is DONTUSE. Furthermore, the result gets the HASSIG tag if any of the constituents do.</li>
 </ul></li>
 <li>If among all valid solutions (including DONTUSE ones) more than one does not have the HASSIG marker, return DONTUSE, as this is malleable because of reason 1.</li>
@@ -591,7 +599,7 @@ The following table lists these additional properties, and the requirements for 
 <tbody>
 <tr><td><code>0</code></td><td></td><td>s, e</td></tr>
 <tr><td><code>1</code></td><td></td><td>f</td></tr>
-<tr><td><code>pk(key)</code></td><td></td><td>s, e</td></tr>
+<tr><td><code>pk_k(key)</code></td><td></td><td>s, e</td></tr>
 <tr><td><code>pk_h(key)</code></td><td></td><td>s, e</td></tr>
 <tr><td><code>older(n)</code></td><td></td><td>f</td></tr>
 <tr><td><code>after(n)</code></td><td></td><td>f</td></tr>
@@ -607,7 +615,7 @@ The following table lists these additional properties, and the requirements for 
 <tr><td><code>or_d(<em>X</em>,<em>Z</em>)</code></td><td>e<sub>X</sub> and (s<sub>X</sub> or s<sub>Z</sub>)</td><td>s=s<sub>X</sub>s<sub>Z</sub>; f=f<sub>Z</sub>; e=e<sub>Z</sub></td></tr>
 <tr><td><code>or_i(<em>X</em>,<em>Z</em>)</code></td><td>s<sub>X</sub> or s<sub>Z</sub></td><td>s=s<sub>X</sub>s<sub>Z</sub>; f=f<sub>X</sub>f<sub>Z</sub>; e=e<sub>X</sub>f<sub>Z</sub> or e<sub>Z</sub>f<sub>X</sub></td></tr>
 <tr><td><code>thresh(k,<em>X<sub>1</sub></em>,...,<em>X<sub>n</sub></em>)</code></td><td>all are e; at most k are non-s</td><td>s=at most k-1 are non-s; e=all are s</td></tr>
-<tr><td><code>thresh_m(k,key<sub>1</sub>,...,key<sub>n</sub>)</code></td><td></td><td>s; e</td></tr>
+<tr><td><code>multi(k,key<sub>1</sub>,...,key<sub>n</sub>)</code></td><td></td><td>s; e</td></tr>
 <tr><td><code>a:<em>X</em></code></td><td></td><td>s=s<sub>X</sub>; f=f<sub>X</sub>; e=e<sub>X</sub></td></tr>
 <tr><td><code>s:<em>X</em></code></td><td></td><td>s=s<sub>X</sub>; f=f<sub>X</sub>; e=e<sub>X</sub></td></tr>
 <tr><td><code>c:<em>X</em></code></td><td></td><td>s; e=e<sub>X</sub></td></tr>

--- a/js_bindings.cpp
+++ b/js_bindings.cpp
@@ -41,17 +41,17 @@ std::string Props(const miniscript::NodeRef<std::string>& node, std::string in) 
 
 std::string Analyze(const miniscript::NodeRef<std::string>& node) {
     switch (node->nodetype) {
-        case miniscript::NodeType::PK: {
+        case miniscript::NodeType::PK_K: {
             std::string str;
             COMPILER_CTX.ToString(node->keys[0], str);
-            return Props(node, "pk(" + std::move(str) + ")");
+            return Props(node, "pk_k(" + std::move(str) + ")");
         }
         case miniscript::NodeType::PK_H: {
             std::string str;
             COMPILER_CTX.ToString(node->keys[0], str);
             return Props(node, "pk_h(" + std::move(str) + ")");
         }
-        case miniscript::NodeType::THRESH_M: return Props(node, "thresh_m(" + std::to_string(node->k) + " of " + std::to_string(node->keys.size()) + ")");
+        case miniscript::NodeType::MULTI: return Props(node, "multi(" + std::to_string(node->k) + " of " + std::to_string(node->keys.size()) + ")");
         case miniscript::NodeType::AFTER: return Props(node, "after(" + std::to_string(node->k) + ")");
         case miniscript::NodeType::OLDER: return Props(node, "older(" + std::to_string(node->k) + ")");
         case miniscript::NodeType::SHA256: return Props(node, "sha256()");


### PR DESCRIPTION
This changes the Miniscript language:
* Rename `pk` to `pk_k`
* Rename `thresh_m` to `multi`
* Add alias `pk(K)` = `c:pk_k(K)`
* Add alias `pkh(K)` = `c:pk_h(K)`

See discussion in https://github.com/bitcoin/bitcoin/pull/16800#issuecomment-585391070 for more details.
