### PR TITLE
Use hex notation in the translation table

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,22 +224,22 @@ wrapper applied to the <code>c:</code> wrapper applied to the <code>pk</code> fr
 <tr>
   <td>len(x) = 32 and SHA256(x) = h</td>
   <td><code>sha256(h)</code></td>
-  <td><samp>SIZE &lt;32&gt; EQUALVERIFY SHA256 &lt;h&gt; EQUAL</samp></td>
+  <td><samp>SIZE &lt;20&gt; EQUALVERIFY SHA256 &lt;h&gt; EQUAL</samp></td>
 </tr>
 <tr>
   <td>len(x) = 32 and HASH256(x) = h</td>
   <td><code>hash256(h)</code></td>
-  <td><samp>SIZE &lt;32&gt; EQUALVERIFY HASH256 &lt;h&gt; EQUAL</samp></td>
+  <td><samp>SIZE &lt;20&gt; EQUALVERIFY HASH256 &lt;h&gt; EQUAL</samp></td>
 </tr>
 <tr>
   <td>len(x) = 32 and RIPEMD160(x) = h</td>
   <td><code>ripemd160(h)</code></td>
-  <td><samp>SIZE &lt;32&gt; EQUALVERIFY RIPEMD160 &lt;h&gt; EQUAL</samp></td>
+  <td><samp>SIZE &lt;20&gt; EQUALVERIFY RIPEMD160 &lt;h&gt; EQUAL</samp></td>
 </tr>
 <tr>
   <td>len(x) = 32 and HASH160(x) = h</td>
   <td><code>hash160(h)</code></td>
-  <td><samp>SIZE &lt;32&gt; EQUALVERIFY HASH160 &lt;h&gt; EQUAL</samp></td>
+  <td><samp>SIZE &lt;20&gt; EQUALVERIFY HASH160 &lt;h&gt; EQUAL</samp></td>
 <tr>
   <td>(<em>X</em> and <em>Y</em>) or <em>Z</em></td>
   <td><code>andor(<em>X</em>,<em>Y</em>,<em>Z</em>)</code></td>


### PR DESCRIPTION
To match the compiler's output.