### PR TITLE
Fix properties of d: wrapper

### DIFF
--- a/index.html
+++ b/index.html
@@ -402,7 +402,7 @@ This tables lists the correctness requirements for each of the Miniscript expres
 <tr><td><code>a:X</code></td><td><em>X</em> is B</td><td>W</td><td>d=d<sub>X</sub>; u=u<sub>X</sub></td></tr>
 <tr><td><code>s:X</code></td><td><em>X</em> is Bo</td><td>W</td><td>d=d<sub>X</sub>; u=u<sub>X</sub></td></tr>
 <tr><td><code>c:X</code></td><td><em>X</em> is K</td><td>B</td><td>o=o<sub>X</sub>; n=n<sub>X</sub>; d=d<sub>X</sub>; u</td></tr>
-<tr><td><code>d:X</code></td><td><em>X</em> is Vz</td><td>B</td><td>o=z<sub>X</sub>; n; u; d</td></tr>
+<tr><td><code>d:X</code></td><td><em>X</em> is Vz</td><td>B</td><td>o; n; d; u</td></tr>
 <tr><td><code>v:X</code></td><td><em>X</em> is B</td><td>V</td><td>z=z<sub>X</sub>; o=o<sub>X</sub>; n=n<sub>X</sub></td></tr>
 <tr><td><code>j:X</code></td><td><em>X</em> is Bn</td><td>B</td><td>o=o<sub>X</sub>; n; d; u=u<sub>X</sub></td></tr>
 <tr><td><code>n:X</code></td><td><em>X</em> is B</td><td>B</td><td>z=z<sub>X</sub>; o=o<sub>X</sub>; n=n<sub>X</sub>; d=d<sub>X</sub>; u</td></tr>
@@ -483,7 +483,7 @@ are listed for completeness, but marked in <span class="text-muted">[grey]</span
 <tr><td><code>a:<em>X</em></code></td><td>dsat(<em>X</em>)</td><td>sat(<em>X</em>)</td></tr>
 <tr><td><code>s:<em>X</em></code></td><td>dsat(<em>X</em>)</td><td>sat(<em>X</em>)</td></tr>
 <tr><td><code>c:<em>X</em></code></td><td>dsat(<em>X</em>)</td><td>sat(<em>X</em>)</td></tr>
-<tr><td><code>d:<em>X</em></code></td><td>0</td><td>sat(<em>X</em>) 1</td></tr>
+<tr><td><code>d:<em>X</em></code></td><td>0</td><td>1</td></tr>
 <tr><td><code>v:<em>X</em></code></td><td>-</td><td>sat(<em>X</em>)</td></tr>
 <tr><td><code>j:<em>X</em></code></td><td>0; <span class="text-muted">[dsat(<em>X</em>) (if nonzero top stack)]</span></td><td>sat(<em>X</em>)</td></tr>
 <tr><td><code>n:<em>X</em></code></td><td>dsat(<em>X</em>)</td><td>sat(<em>X</em>)</td></tr>


### PR DESCRIPTION
As discussed in https://github.com/sipa/miniscript/issues/49,
the `d:` wrapper requires z modifier, and therefore the `o` property
is unconditional. sat(X) is also redundant for satisfaction of `d:`,
because if X is dissatisfied, it will abort (being `V`).

I also changed the order of properties of `d:` from `o; n; u; d` to `o; n; d; u` for cosmetic reasons, as other rows use the later order.