### PR TITLE
Fix type modifiers for NodeType::WRAP_C: should not inherit "f"

### DIFF
--- a/bitcoin/script/miniscript.cpp
+++ b/bitcoin/script/miniscript.cpp
@@ -97,7 +97,7 @@ Type ComputeType(NodeType nodetype, Type x, Type y, Type z, const std::vector<Ty
             (x & "udfemsx"_mst); // u=u_x, d=d_x, f=f_x, e=e_x, m=m_x, s=s_x, x=x_x
         case NodeType::WRAP_C: return
             "B"_mst.If(x << "K"_mst) | // B=K_x
-             (x & "ondfem"_mst) | // o=o_x, n=n_x, d=d_x, f=f_x, e=e_x, m=m_x
+             (x & "ondem"_mst) | // o=o_x, n=n_x, d=d_x, e=e_x, m=m_x
              "us"_mst; // u, s
         case NodeType::WRAP_D: return
             "B"_mst.If(x << "Vz"_mst) | // B=V_x*z_x


### PR DESCRIPTION
"f" means dissatisfying the expression requires signature.
"c:" wrapper should not inherit the "f" type modifier from its
argument, because to dissatisfy "c:", an empty signature is enough

The specification don't list "f" for "c:", so passing "f" from the argument of "c:" does not correspond to the spec.

This was detected in with the help of automated testcase generation using https://github.com/dgpv/miniscript-alloy-spec (ad-hoc GUI automation to generate many `.dot` files from the instances generated by Alloy, and `tools/parse_miniscript_dot.py` scrip to convert `.dot` to the format that miniscript binary gives out)