### PR TITLE
Fix non-malleability type modifiers for c: wrapper (should inherit "f")

### DIFF
--- a/index.html
+++ b/index.html
@@ -618,7 +618,7 @@ The following table lists these additional properties, and the requirements for 
 <tr><td><code>multi(k,key<sub>1</sub>,...,key<sub>n</sub>)</code></td><td></td><td>s; e</td></tr>
 <tr><td><code>a:<em>X</em></code></td><td></td><td>s=s<sub>X</sub>; f=f<sub>X</sub>; e=e<sub>X</sub></td></tr>
 <tr><td><code>s:<em>X</em></code></td><td></td><td>s=s<sub>X</sub>; f=f<sub>X</sub>; e=e<sub>X</sub></td></tr>
-<tr><td><code>c:<em>X</em></code></td><td></td><td>s; e=e<sub>X</sub></td></tr>
+<tr><td><code>c:<em>X</em></code></td><td></td><td>s; f=f<sub>X</sub>; e=e<sub>X</sub></td></tr>
 <tr><td><code>d:<em>X</em></code></td><td></td><td>s=s<sub>X</sub>; e</td></tr>
 <tr><td><code>v:<em>X</em></code></td><td></td><td>s=s<sub>X</sub>; f</td></tr>
 <tr><td><code>j:<em>X</em></code></td><td></td><td>s=s<sub>X</sub>; e=f<sub>X</sub></td></tr>


### PR DESCRIPTION
As discussed in #51, the `c:` wrapper should inherit the "f" type modifier from its argument. The code was correct while the spec wasn't