### PR TITLE
Inclusive bounds for `thresh()`'s threshold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+miniscript

--- a/bitcoin/script/miniscript.cpp
+++ b/bitcoin/script/miniscript.cpp
@@ -48,7 +48,7 @@ Type ComputeType(NodeType nodetype, Type x, Type y, Type z, const std::vector<Ty
     } else if (nodetype == NodeType::MULTI) {
         assert(k >= 1 && k <= n_keys);
     } else if (nodetype == NodeType::THRESH) {
-        assert(k > 1 && k < n_subs);
+        assert(k >= 1 && k <= n_subs);
     } else {
         assert(k == 0);
     }

--- a/bitcoin/script/miniscript.h
+++ b/bitcoin/script/miniscript.h
@@ -960,7 +960,7 @@ inline NodeRef<Key> Parse(Span<const char>& in, const Ctx& ctx, int recursion_de
             if (!sub) return {};
             subs.push_back(std::move(sub));
         }
-        if (count <= 1 || count >= (int64_t)subs.size()) return {};
+        if (count < 1 || count > (int64_t)subs.size()) return {};
         return MakeNodeRef<Key>(NodeType::THRESH, std::move(subs), count);
     } else if (Func("and_v", expr)) {
         nodetype = NodeType::AND_V;

--- a/compiler.cpp
+++ b/compiler.cpp
@@ -320,9 +320,6 @@ const Strat* ComputeStrategy(const Policy& node, std::unordered_map<const Policy
                 }
                 strats.push_back(MakeStrat(store, Strat::Type::MULTI, std::move(keys), node.k));
             }
-            if (node.k > 1 && node.k < node.sub.size()) {
-                strats.push_back(MakeStrat(store, Strat::Type::THRESH, subs, node.k, (double)node.k / subs.size()));
-            }
             if (node.k == 1 || node.k == node.sub.size()) {
                 while (subs.size() > 1) {
                     auto rep = MakeStrat(store, node.k == 1 ? Strat::Type::OR : Strat::Type::AND, Vector(*(subs.rbegin() + 1), subs.back()), 1.0 / subs.size());
@@ -332,6 +329,7 @@ const Strat* ComputeStrategy(const Policy& node, std::unordered_map<const Policy
                 }
                 strats.push_back(subs[0]);
             }
+            strats.push_back(MakeStrat(store, Strat::Type::THRESH, subs, node.k, (double)node.k / subs.size()));
             break;
         }
     }

--- a/index.html
+++ b/index.html
@@ -397,7 +397,7 @@ This tables lists the correctness requirements for each of the Miniscript expres
 <tr><td><code>or_c(<em>X</em>,<em>Z</em>)</code></td><td><em>X</em> is Bdu; <em>Z</em> is V</td><td>V</td><td>z=z<sub>X</sub>z<sub>Z</sub>; o=o<sub>X</sub>z<sub>Z</sub></td></tr>
 <tr><td><code>or_d(<em>X</em>,<em>Z</em>)</code></td><td><em>X</em> is Bdu; <em>Z</em> is B</td><td>B</td><td>z=z<sub>X</sub>z<sub>Z</sub>; o=o<sub>X</sub>z<sub>Z</sub>; d=d<sub>Z</sub>; u=u<sub>Z</sub></td></tr>
 <tr><td><code>or_i(<em>X</em>,<em>Z</em>)</code></td><td>both are B, K, or V</td><td>same as X/Z</td><td>o=z<sub>X</sub>z<sub>Z</sub>; u=u<sub>X</sub>u<sub>Z</sub>; d=d<sub>X</sub> or d<sub>Z</sub></td></tr>
-<tr><td><code>thresh(k,<em>X<sub>1</sub></em>,...,<em>X<sub>n</sub></em>)</code></td><td>1 &lt; k &lt; n; <em>X<sub>1</sub></em> is Bdu; others are Wdu</td><td>B</td><td>z=all are z; o=all are z except one is o; d; u</td></tr>
+<tr><td><code>thresh(k,<em>X<sub>1</sub></em>,...,<em>X<sub>n</sub></em>)</code></td><td>1 &le; k &le; n; <em>X<sub>1</sub></em> is Bdu; others are Wdu</td><td>B</td><td>z=all are z; o=all are z except one is o; d; u</td></tr>
 <tr><td><code>multi(k,key<sub>1</sub>,...,key<sub>n</sub>)</code></td><td>1 &le; k &le; n</td><td>B</td><td>n; d; u</td></tr>
 <tr><td><code>a:X</code></td><td><em>X</em> is B</td><td>W</td><td>d=d<sub>X</sub>; u=u<sub>X</sub></td></tr>
 <tr><td><code>s:X</code></td><td><em>X</em> is Bo</td><td>W</td><td>d=d<sub>X</sub>; u=u<sub>X</sub></td></tr>


### PR DESCRIPTION
As per https://github.com/sipa/miniscript/issues/39 and discussions on IRC this removes the exclusion of `k = 1` and `k = subs.size()` for `thresh`.

This is the opposite of https://github.com/rust-bitcoin/rust-miniscript/pull/242 (adapting the Rust implementation to the C++ one) after sanket1729 's feedback.

Fixes #39