### PR TITLE
Limit the number of opcodes in FromScript

### DIFF
--- a/bitcoin/script/miniscript.cpp
+++ b/bitcoin/script/miniscript.cpp
@@ -301,7 +301,7 @@ InputStack Choose(InputStack a, InputStack b, bool nonmalleable) {
     }
 }
 
-bool DecomposeScript(const CScript& script, std::vector<std::pair<opcodetype, std::vector<unsigned char>>>& out)
+bool DecomposeScript(const CScript& script, std::vector<std::pair<opcodetype, std::vector<unsigned char>>>& out, int& out_pushops)
 {
     out.clear();
     CScript::const_iterator it = script.begin(), itend = script.end();
@@ -327,6 +327,7 @@ bool DecomposeScript(const CScript& script, std::vector<std::pair<opcodetype, st
             out.emplace_back(OP_EQUAL, std::vector<unsigned char>());
             opcode = OP_VERIFY;
         }
+        if (!push_data.empty()) out_pushops++;
         out.emplace_back(opcode, std::move(push_data));
     }
     std::reverse(out.begin(), out.end());

--- a/bitcoin/script/miniscript.h
+++ b/bitcoin/script/miniscript.h
@@ -1009,7 +1009,7 @@ inline NodeRef<Key> Parse(Span<const char>& in, const Ctx& ctx, int recursion_de
  * and OP_EQUALVERIFY are decomposed into OP_CHECKSIG, OP_CHECKMULTISIG, OP_EQUAL
  * respectively, plus OP_VERIFY.
  */
-bool DecomposeScript(const CScript& script, std::vector<std::pair<opcodetype, std::vector<unsigned char>>>& out);
+bool DecomposeScript(const CScript& script, std::vector<std::pair<opcodetype, std::vector<unsigned char>>>& out, int& out_pushops);
 
 /** Determine whether the passed pair (created by DecomposeScript) is pushing a number. */
 bool ParseScriptNumber(const std::pair<opcodetype, std::vector<unsigned char>>& in, int64_t& k);
@@ -1249,7 +1249,9 @@ template<typename Ctx>
 inline NodeRef<typename Ctx::Key> FromScript(const CScript& script, const Ctx& ctx) {
     using namespace internal;
     std::vector<std::pair<opcodetype, std::vector<unsigned char>>> decomposed;
-    if (!DecomposeScript(script, decomposed)) return {};
+    int pushops = 0;
+    if (!DecomposeScript(script, decomposed, pushops)) return {};
+    if (decomposed.size() - pushops > 201) return {};
     auto it = decomposed.begin();
     auto ret = DecodeMulti<typename Ctx::Key>(it, decomposed.end(), ctx);
     if (!ret) return {};


### PR DESCRIPTION
I think this is a trivial fix to issue #14 (fixes #14)

May be redundant if we decide to make these functions non-recursive though.