### PR TITLE
Remove duplicate if statements

### DIFF
--- a/bitcoin/script/miniscript.h
+++ b/bitcoin/script/miniscript.h
@@ -410,7 +410,7 @@ private:
                     return std::move(ret) + "pk(" + std::move(key_str) + ")";
                 }
                 if (subs[0]->nodetype == NodeType::PK_H) {
-                    // pkh(K) is syntactix sugar for c:pk_h(K)
+                    // pkh(K) is syntactic sugar for c:pk_h(K)
                     std::string key_str;
                     success = ctx.ToString(subs[0]->keys[0], key_str);
                     return std::move(ret) + "pkh(" + std::move(key_str) + ")";
@@ -899,10 +899,6 @@ inline NodeRef<Key> Parse(Span<const char>& in, const Ctx& ctx, int recursion_de
             return MakeNodeRef<Key>(NodeType::PK_H, Vector(std::move(key)));
         }
         return {};
-    } else if (expr == MakeSpan("0")) {
-        return MakeNodeRef<Key>(NodeType::JUST_0);
-    } else if (expr == MakeSpan("1")) {
-        return MakeNodeRef<Key>(NodeType::JUST_1);
     } else if (Func("sha256", expr)) {
         std::string val = std::string(expr.begin(), expr.end());
         if (!IsHex(val)) return {};


### PR DESCRIPTION
Checks for JUST_0 and JUST_1 are done earlier, and these don't actually work (`MakeSpan("0")` has length 2 because of the string terminator)