### PR TITLE
miniscript: WRAP_N should have the 'x' type property

### DIFF
--- a/bitcoin/script/miniscript.cpp
+++ b/bitcoin/script/miniscript.cpp
@@ -115,6 +115,7 @@ Type ComputeType(NodeType nodetype, Type x, Type y, Type z, const std::vector<Ty
             (x & "oums"_mst) | // o=o_x, u=u_x, m=m_x, s=s_x
             "ndx"_mst; // n, d, x
         case NodeType::WRAP_N: return
+            "x"_mst | // 0NOTEQUAL doesn't have a VERIFY version
             (x & "Bzondfems"_mst) | // B=B_x, z=z_x, o=o_x, n=n_x, d=d_x, f=f_x, e=e_x, m=m_x, s=s_x
             "ux"_mst; // u, x
         case NodeType::AND_V: return


### PR DESCRIPTION
TIL: `0NOTEQUAL` and `NUMNOTEQUAL` are the two only "`EQUAL` family" opcodes which don't have a `VERIFY` version