### PR TITLE
miniscript: check thresh bounds when parsing a script

### DIFF
--- a/bitcoin/script/miniscript.h
+++ b/bitcoin/script/miniscript.h
@@ -1338,6 +1338,7 @@ inline NodeRef<Key> DecodeScript(I& in, I last, const Ctx& ctx) {
             break;
         }
         case DecodeContext::THRESH_E: {
+            if (k < 1 || k > n) return {};
             std::vector<NodeRef<Key>> subs;
             for (int i = 0; i < n; ++i) {
                 NodeRef<Key> sub = std::move(constructed.back());


### PR DESCRIPTION
We could eg parse a thresh with a `k` of `0` and later crash when asserting a sane `thresh` fragment. See https://github.com/sipa/miniscript/pull/66#discussion_r716180242