### PR TITLE
Miniscript validity and Script decoding checks

### DIFF
--- a/bitcoin/policy/policy.h
+++ b/bitcoin/policy/policy.h
@@ -3,4 +3,7 @@
 
 static const unsigned int MAX_STANDARD_P2WSH_STACK_ITEMS = 100;
 
+/** The maximum size in bytes of a standard witnessScript */
+static const unsigned int MAX_STANDARD_P2WSH_SCRIPT_SIZE = 3600;
+
 #endif

--- a/bitcoin/script/miniscript.h
+++ b/bitcoin/script/miniscript.h
@@ -105,7 +105,7 @@ class Type {
     //! Internal bitmap of properties (see ""_mst operator for details).
     uint16_t m_flags;
 
-    //! Internal constructed used by the ""_mst operator.
+    //! Internal constructor used by the ""_mst operator.
     explicit constexpr Type(uint16_t flags) : m_flags(flags) {}
 
 public:
@@ -753,10 +753,10 @@ public:
     Type GetType() const { return typ; }
 
     //! Check whether this node is valid at all.
-    bool IsValid() const { return !(GetType() == ""_mst); }
+    bool IsValid() const { return !(GetType() == ""_mst) && ScriptSize() <= MAX_STANDARD_P2WSH_SCRIPT_SIZE; }
 
     //! Check whether this node is valid as a script on its own.
-    bool IsValidTopLevel() const { return GetType() << "B"_mst; }
+    bool IsValidTopLevel() const { return IsValid() && GetType() << "B"_mst; }
 
     //! Check whether this script can always be satisfied in a non-malleable way.
     bool IsNonMalleable() const { return GetType() << "m"_mst; }

--- a/index.html
+++ b/index.html
@@ -423,7 +423,8 @@ Various types of Bitcoin Scripts have different resource limitations, either thr
 <li>Script satisfactions with a serialized <samp>scriptSig</samp> over 1650 bytes are invalid by standardness (P2SH).</li>
 <li>Script satisfactions with a witness consisting of over 100 stack elements (excluding the script itself) are invalid by standardness (P2WSH, P2SH-P2WSH).</li>
 </ul>
-Miniscript makes it easy to verify that the ability to satisfy a script is not impacted by these limits. Note that this is different from verifying whether the limits are never
+For P2WSH, a Miniscript whose script is larger than 3600 bytes is invalid.
+For all the other limits, Miniscript makes it easy to verify they don't impact the ability to satisfy a script. Note that this is different from verifying whether the limits are never
 reachable at all (which is also possible). Consider for example an <code>or_b(<em>X</em>,<em>Y</em>)</code> where both <em>X</em> and <em>Y</em> require a number of large <code>multi</code>s
 to be executed to satisfy. It may be the case that satisfying just one of <em>X</em> or <em>Y</em> does not exceed the ops limit, while satisfying both does. As it's never required to
 satisfy both, the limit does not prevent satisfaction.


### PR DESCRIPTION
This makes Miniscripts which script is invalid by standradness invalid and check nodes are valid when decoding from Script.