### PR TITLE
Miniscript safety

### DIFF
--- a/bitcoin/script/miniscript.h
+++ b/bitcoin/script/miniscript.h
@@ -784,10 +784,10 @@ public:
     bool NeedsSignature() const { return GetType() << "s"_mst; }
 
     //! Do all sanity checks.
-    bool IsSafe() const { return GetType() << "msk"_mst && CheckOpsLimit() && CheckStackSize() && IsValid(); }
+    bool IsSane() const { return GetType() << "mk"_mst && CheckOpsLimit() && CheckStackSize() && IsValid(); }
 
     //! Check whether this node is safe as a script on its own.
-    bool IsSafeTopLevel() const { return GetType() << "B"_mst && IsSafe() && IsValidTopLevel(); }
+    bool IsSaneTopLevel() const { return GetType() << "Bs"_mst && IsSane() && IsValidTopLevel(); }
 
     //! Construct the script for this miniscript (including subexpressions).
     template<typename Ctx>

--- a/bitcoin/script/miniscript.h
+++ b/bitcoin/script/miniscript.h
@@ -784,7 +784,10 @@ public:
     bool NeedsSignature() const { return GetType() << "s"_mst; }
 
     //! Do all sanity checks.
-    bool IsSafeTopLevel() const { return GetType() << "Bmsk"_mst && CheckOpsLimit() && CheckStackSize(); }
+    bool IsSafe() const { return GetType() << "msk"_mst && CheckOpsLimit() && CheckStackSize() && IsValid(); }
+
+    //! Check whether this node is safe as a script on its own.
+    bool IsSafeTopLevel() const { return GetType() << "B"_mst && IsSafe() && IsValidTopLevel(); }
 
     //! Construct the script for this miniscript (including subexpressions).
     template<typename Ctx>

--- a/compiler.cpp
+++ b/compiler.cpp
@@ -406,11 +406,9 @@ struct Compilation {
     }
 
     void Add(const CostPair& pair, Node node) {
+        if (!node->IsSane()) return;
         auto new_typ = node->GetType();
         double cost = Cost(pair, node);
-        if (!node->CheckOpsLimit()) return;
-        if (node->GetStackSize() > MAX_STANDARD_P2WSH_STACK_ITEMS) return;
-        if (!(new_typ << "mk"_mst)) return;
         if (cost > 10000) return;
         for (const Result& x : results) {
             auto old_typ = x.node->GetType();


### PR DESCRIPTION
Based on #72 this separates `IsSafe` and `IsSafeTopLevel` as suggested in https://github.com/sipa/miniscript/pull/41#discussion_r716035958 .