### PR TITLE
miniscript: correct the stack size check

### DIFF
--- a/bitcoin/script/miniscript.h
+++ b/bitcoin/script/miniscript.h
@@ -747,7 +747,7 @@ public:
     uint32_t GetStackSize() const { return ss.sat.value + 1; }
 
     //! Check the maximum stack size for this script against the policy limit.
-    bool CheckStackSize() const { return GetStackSize() <= MAX_STANDARD_P2WSH_STACK_ITEMS; }
+    bool CheckStackSize() const { return GetStackSize() - 1 <= MAX_STANDARD_P2WSH_STACK_ITEMS; }
 
     //! Return the expression type.
     Type GetType() const { return typ; }


### PR DESCRIPTION
bitcoind does not account for the witness script push when checking against `MAX_STANDARD_P2WSH_STACK_ITEMS`
```cpp
size_t sizeWitnessStack = tx.vin[i].scriptWitness.stack.size() - 1;
if (sizeWitnessStack > MAX_STANDARD_P2WSH_STACK_ITEMS)
	return false;
```