### PR TITLE
fuzz: add a fuzz target for Miniscript decoding

### DIFF
--- a/bitcoin/script/miniscript.h
+++ b/bitcoin/script/miniscript.h
@@ -1634,58 +1634,69 @@ inline NodeRef<Key> DecodeScript(I& in, I last, const Ctx& ctx)
             break;
         }
         case DecodeContext::SWAP: {
-            if (in >= last || in[0].first != OP_SWAP) return {};
+            if (in >= last || in[0].first != OP_SWAP || constructed.empty()) return {};
             ++in;
             constructed.back() = MakeNodeRef<Key>(NodeType::WRAP_S, Vector(std::move(constructed.back())));
             break;
         }
         case DecodeContext::ALT: {
-            if (in >= last || in[0].first != OP_TOALTSTACK) return {};
+            if (in >= last || in[0].first != OP_TOALTSTACK || constructed.empty()) return {};
             ++in;
             constructed.back() = MakeNodeRef<Key>(NodeType::WRAP_A, Vector(std::move(constructed.back())));
             break;
         }
         case DecodeContext::CHECK: {
+            if (constructed.empty()) return {};
             constructed.back() = MakeNodeRef<Key>(NodeType::WRAP_C, Vector(std::move(constructed.back())));
             break;
         }
         case DecodeContext::DUP_IF: {
+            if (constructed.empty()) return {};
             constructed.back() = MakeNodeRef<Key>(NodeType::WRAP_D, Vector(std::move(constructed.back())));
             break;
         }
         case DecodeContext::VERIFY: {
+            if (constructed.empty()) return {};
             constructed.back() = MakeNodeRef<Key>(NodeType::WRAP_V, Vector(std::move(constructed.back())));
             break;
         }
         case DecodeContext::NON_ZERO: {
+            if (constructed.empty()) return {};
             constructed.back() = MakeNodeRef<Key>(NodeType::WRAP_J, Vector(std::move(constructed.back())));
             break;
         }
         case DecodeContext::ZERO_NOTEQUAL: {
+            if (constructed.empty()) return {};
             constructed.back() = MakeNodeRef<Key>(NodeType::WRAP_N, Vector(std::move(constructed.back())));
             break;
         }
         case DecodeContext::AND_V: {
+            if (constructed.size() < 2) return {};
             BuildBack(NodeType::AND_V, constructed, /* reverse */ true);
             break;
         }
         case DecodeContext::AND_B: {
+            if (constructed.size() < 2) return {};
             BuildBack(NodeType::AND_B, constructed, /* reverse */ true);
             break;
         }
         case DecodeContext::OR_B: {
+            if (constructed.size() < 2) return {};
             BuildBack(NodeType::OR_B, constructed, /* reverse */ true);
             break;
         }
         case DecodeContext::OR_C: {
+            if (constructed.size() < 2) return {};
             BuildBack(NodeType::OR_C, constructed, /* reverse */ true);
             break;
         }
         case DecodeContext::OR_D: {
+            if (constructed.size() < 2) return {};
             BuildBack(NodeType::OR_D, constructed, /* reverse */ true);
             break;
         }
         case DecodeContext::ANDOR: {
+            if (constructed.size() < 3) return {};
             NodeRef<Key> left = std::move(constructed.back());
             constructed.pop_back();
             NodeRef<Key> right = std::move(constructed.back());
@@ -1708,7 +1719,7 @@ inline NodeRef<Key> DecodeScript(I& in, I last, const Ctx& ctx)
             break;
         }
         case DecodeContext::THRESH_E: {
-            if (k < 1 || k > n) return {};
+            if (k < 1 || k > n || constructed.size() < static_cast<size_t>(n)) return {};
             std::vector<NodeRef<Key>> subs;
             for (int i = 0; i < n; ++i) {
                 NodeRef<Key> sub = std::move(constructed.back());

--- a/bitcoin/test/fuzz/miniscript_decode.cpp
+++ b/bitcoin/test/fuzz/miniscript_decode.cpp
@@ -1,0 +1,72 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <core_io.h>
+#include <hash.h>
+#include <key.h>
+#include <script/miniscript.h>
+#include <script/script.h>
+#include <span.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <util/strencodings.h>
+
+#include <optional>
+
+using miniscript::operator""_mst;
+
+
+struct Converter {
+    typedef CPubKey Key;
+
+    bool ToString(const Key& key, std::string& ret) const {
+        ret = HexStr(key);
+        return true;
+    }
+    const std::vector<unsigned char> ToPKBytes(const Key& key) const {
+        return {key.begin(), key.end()};
+    }
+    const std::vector<unsigned char> ToPKHBytes(const Key& key) const {
+        const auto h = Hash160(key);
+        return {h.begin(), h.end()};
+    }
+
+    template<typename I>
+    bool FromString(I first, I last, Key& key) const {
+        const auto bytes = ParseHex(std::string(first, last));
+        key.Set(bytes.begin(), bytes.end());
+        return key.IsValid();
+    }
+    template<typename I>
+    bool FromPKBytes(I first, I last, CPubKey& key) const {
+        key.Set(first, last);
+        return key.IsValid();
+    }
+    template<typename I>
+    bool FromPKHBytes(I first, I last, CPubKey& key) const {
+        assert(last - first == 20);
+        return false;
+    }
+};
+
+const Converter CONVERTER;
+
+FUZZ_TARGET(miniscript_decode)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    const std::optional<CScript> script = ConsumeDeserializable<CScript>(fuzzed_data_provider);
+    if (!script) return;
+
+    const auto ms = miniscript::FromScript(*script, CONVERTER);
+    if (!ms) return;
+
+    // We can roundtrip it to its string representation.
+    std::string ms_str;
+    assert(ms->ToString(CONVERTER, ms_str));
+    assert(*miniscript::FromString(ms_str, CONVERTER) == *ms);
+    // The Script representation must roundtrip since we parsed it this way the first time.
+    const CScript ms_script = ms->ToScript(CONVERTER);
+    assert(ms_script == *script);
+}


### PR DESCRIPTION
This isn't compiled by default in this repo since i didn't want to pull the whole fuzzing stuff from Bitcoin Core for something that should be upstreamed soon.

A minified fuzzing corpus for this target can be found at https://github.com/darosior/qa-assets/tree/miniscript_decode_corpus/fuzz_seed_corpus/miniscript_decode .

Note that there is already a fuzz target for parsing descriptors so there is no need to add one specific to Miniscript. I'll grow a Miniscript corpus for this when i'm done with the Miniscript integration in the descriptor wallet.