### PR TITLE
Simplify TreeEvalMaybe

### DIFF
--- a/bitcoin/script/miniscript.h
+++ b/bitcoin/script/miniscript.h
@@ -424,8 +424,8 @@ private:
             // If evaluation returns std::nullopt, abort immediately.
             if (!result) return {};
             // Replace the last node.subs.size() elements of results with the new result.
-            results.resize(results.size() - node.subs.size() + 1);
-            results.back() = std::move(*result);
+            results.erase(results.end() - node.subs.size(), results.end());
+            results.push_back(std::move(*result));
             stack.pop_back();
         }
         // The final remaining results element is the root result, return it.


### PR DESCRIPTION
A very localized improvement to the TreeEvalMaybe algorithm.

Instead of always expanding all children of a node at once whenever we first encounter it, expand them one by one, always returning processing to the parent in between. This doesn't matter much right now, but is conceptually simpler, and may be beneficial later:
* The stack variable now just contains at most 1 element per tree depth, rather than up to depth * branching_factor.
* The `downfn` function is now called in order (left to right) for all the children, making it more much more intuitive.
* Related to the previous point, make it possible for `downfn` to modify the parent's state.
