### PR TITLE
Pseudo-random node generation from fuzzer's input using a strict binary encoding

### DIFF
--- a/bitcoin/script/miniscript.cpp
+++ b/bitcoin/script/miniscript.cpp
@@ -35,42 +35,42 @@ Type SanitizeType(Type e) {
     return e;
 }
 
-Type ComputeType(NodeType nodetype, Type x, Type y, Type z, const std::vector<Type>& sub_types, uint32_t k, size_t data_size, size_t n_subs, size_t n_keys) {
+Type ComputeType(Fragment nodetype, Type x, Type y, Type z, const std::vector<Type>& sub_types, uint32_t k, size_t data_size, size_t n_subs, size_t n_keys) {
     // Sanity check on data
-    if (nodetype == NodeType::SHA256 || nodetype == NodeType::HASH256) {
+    if (nodetype == Fragment::SHA256 || nodetype == Fragment::HASH256) {
         assert(data_size == 32);
-    } else if (nodetype == NodeType::RIPEMD160 || nodetype == NodeType::HASH160) {
+    } else if (nodetype == Fragment::RIPEMD160 || nodetype == Fragment::HASH160) {
         assert(data_size == 20);
     } else {
         assert(data_size == 0);
     }
     // Sanity check on k
-    if (nodetype == NodeType::OLDER || nodetype == NodeType::AFTER) {
+    if (nodetype == Fragment::OLDER || nodetype == Fragment::AFTER) {
         assert(k >= 1 && k < 0x80000000UL);
-    } else if (nodetype == NodeType::MULTI) {
+    } else if (nodetype == Fragment::MULTI) {
         assert(k >= 1 && k <= n_keys);
-    } else if (nodetype == NodeType::THRESH) {
+    } else if (nodetype == Fragment::THRESH) {
         assert(k >= 1 && k <= n_subs);
     } else {
         assert(k == 0);
     }
     // Sanity check on subs
-    if (nodetype == NodeType::AND_V || nodetype == NodeType::AND_B || nodetype == NodeType::OR_B ||
-        nodetype == NodeType::OR_C || nodetype == NodeType::OR_I || nodetype == NodeType::OR_D) {
+    if (nodetype == Fragment::AND_V || nodetype == Fragment::AND_B || nodetype == Fragment::OR_B ||
+        nodetype == Fragment::OR_C || nodetype == Fragment::OR_I || nodetype == Fragment::OR_D) {
         assert(n_subs == 2);
-    } else if (nodetype == NodeType::ANDOR) {
+    } else if (nodetype == Fragment::ANDOR) {
         assert(n_subs == 3);
-    } else if (nodetype == NodeType::WRAP_A || nodetype == NodeType::WRAP_S || nodetype == NodeType::WRAP_C ||
-               nodetype == NodeType::WRAP_D || nodetype == NodeType::WRAP_V || nodetype == NodeType::WRAP_J ||
-               nodetype == NodeType::WRAP_N) {
+    } else if (nodetype == Fragment::WRAP_A || nodetype == Fragment::WRAP_S || nodetype == Fragment::WRAP_C ||
+               nodetype == Fragment::WRAP_D || nodetype == Fragment::WRAP_V || nodetype == Fragment::WRAP_J ||
+               nodetype == Fragment::WRAP_N) {
         assert(n_subs == 1);
-    } else if (nodetype != NodeType::THRESH) {
+    } else if (nodetype != Fragment::THRESH) {
         assert(n_subs == 0);
     }
     // Sanity check on keys
-    if (nodetype == NodeType::PK_K || nodetype == NodeType::PK_H) {
+    if (nodetype == Fragment::PK_K || nodetype == Fragment::PK_H) {
         assert(n_keys == 1);
-    } else if (nodetype == NodeType::MULTI) {
+    } else if (nodetype == Fragment::MULTI) {
         assert(n_keys >= 1 && n_keys <= 20);
     } else {
         assert(n_keys == 0);
@@ -80,59 +80,59 @@ Type ComputeType(NodeType nodetype, Type x, Type y, Type z, const std::vector<Ty
     // It heavily relies on Type's << operator (where "X << a_mst" means
     // "X has all properties listed in a").
     switch (nodetype) {
-        case NodeType::PK_K: return "Konudemsxk"_mst;
-        case NodeType::PK_H: return "Knudemsxk"_mst;
-        case NodeType::OLDER: return
+        case Fragment::PK_K: return "Konudemsxk"_mst;
+        case Fragment::PK_H: return "Knudemsxk"_mst;
+        case Fragment::OLDER: return
             "g"_mst.If(k & CTxIn::SEQUENCE_LOCKTIME_TYPE_FLAG) |
             "h"_mst.If(!(k & CTxIn::SEQUENCE_LOCKTIME_TYPE_FLAG)) |
             "Bzfmxk"_mst;
-        case NodeType::AFTER: return
+        case Fragment::AFTER: return
             "i"_mst.If(k >= LOCKTIME_THRESHOLD) |
             "j"_mst.If(k < LOCKTIME_THRESHOLD) |
             "Bzfmxk"_mst;
-        case NodeType::SHA256: return "Bonudmk"_mst;
-        case NodeType::RIPEMD160: return "Bonudmk"_mst;
-        case NodeType::HASH256: return "Bonudmk"_mst;
-        case NodeType::HASH160: return "Bonudmk"_mst;
-        case NodeType::JUST_1: return "Bzufmxk"_mst;
-        case NodeType::JUST_0: return "Bzudemsxk"_mst;
-        case NodeType::WRAP_A: return
+        case Fragment::SHA256: return "Bonudmk"_mst;
+        case Fragment::RIPEMD160: return "Bonudmk"_mst;
+        case Fragment::HASH256: return "Bonudmk"_mst;
+        case Fragment::HASH160: return "Bonudmk"_mst;
+        case Fragment::JUST_1: return "Bzufmxk"_mst;
+        case Fragment::JUST_0: return "Bzudemsxk"_mst;
+        case Fragment::WRAP_A: return
             "W"_mst.If(x << "B"_mst) | // W=B_x
             (x & "ghijk"_mst) | // g=g_x, h=h_x, i=i_x, j=j_x, k=k_x
             (x & "udfems"_mst) | // u=u_x, d=d_x, f=f_x, e=e_x, m=m_x, s=s_x
             "x"_mst; // x
-        case NodeType::WRAP_S: return
+        case Fragment::WRAP_S: return
             "W"_mst.If(x << "Bo"_mst) | // W=B_x*o_x
             (x & "ghijk"_mst) | // g=g_x, h=h_x, i=i_x, j=j_x, k=k_x
             (x & "udfemsx"_mst); // u=u_x, d=d_x, f=f_x, e=e_x, m=m_x, s=s_x, x=x_x
-        case NodeType::WRAP_C: return
+        case Fragment::WRAP_C: return
             "B"_mst.If(x << "K"_mst) | // B=K_x
             (x & "ghijk"_mst) | // g=g_x, h=h_x, i=i_x, j=j_x, k=k_x
             (x & "ondfem"_mst) | // o=o_x, n=n_x, d=d_x, f=f_x, e=e_x, m=m_x
             "us"_mst; // u, s
-        case NodeType::WRAP_D: return
+        case Fragment::WRAP_D: return
             "B"_mst.If(x << "Vz"_mst) | // B=V_x*z_x
             "o"_mst.If(x << "z"_mst) | // o=z_x
             "e"_mst.If(x << "f"_mst) | // e=f_x
             (x & "ghijk"_mst) | // g=g_x, h=h_x, i=i_x, j=j_x, k=k_x
             (x & "ms"_mst) | // m=m_x, s=s_x
             "nudx"_mst; // n, u, d, x
-        case NodeType::WRAP_V: return
+        case Fragment::WRAP_V: return
             "V"_mst.If(x << "B"_mst) | // V=B_x
             (x & "ghijk"_mst) | // g=g_x, h=h_x, i=i_x, j=j_x, k=k_x
             (x & "zonms"_mst) | // z=z_x, o=o_x, n=n_x, m=m_x, s=s_x
             "fx"_mst; // f, x
-        case NodeType::WRAP_J: return
+        case Fragment::WRAP_J: return
             "B"_mst.If(x << "Bn"_mst) | // B=B_x*n_x
             "e"_mst.If(x << "f"_mst) | // e=f_x
             (x & "ghijk"_mst) | // g=g_x, h=h_x, i=i_x, j=j_x, k=k_x
             (x & "oums"_mst) | // o=o_x, u=u_x, m=m_x, s=s_x
             "ndx"_mst; // n, d, x
-        case NodeType::WRAP_N: return
+        case Fragment::WRAP_N: return
             (x & "ghijk"_mst) | // g=g_x, h=h_x, i=i_x, j=j_x, k=k_x
             (x & "Bzondfems"_mst) | // B=B_x, z=z_x, o=o_x, n=n_x, d=d_x, f=f_x, e=e_x, m=m_x, s=s_x
             "ux"_mst; // u, x
-        case NodeType::AND_V: return
+        case Fragment::AND_V: return
             (y & "KVB"_mst).If(x << "V"_mst) | // B=V_x*B_y, V=V_x*V_y, K=V_x*K_y
             (x & "n"_mst) | (y & "n"_mst).If(x << "z"_mst) | // n=n_x+z_x*n_y
             ((x | y) & "o"_mst).If((x | y) << "z"_mst) | // o=o_x*z_y+z_x*o_y
@@ -146,7 +146,7 @@ Type ComputeType(NodeType nodetype, Type x, Type y, Type z, const std::vector<Ty
                 ((x << "h"_mst) && (y << "g"_mst)) ||
                 ((x << "i"_mst) && (y << "j"_mst)) ||
                 ((x << "j"_mst) && (y << "i"_mst)))); // k=k_x*k_y*!(g_x*h_y + h_x*g_y + i_x*j_y + j_x*i_y)
-        case NodeType::AND_B: return
+        case Fragment::AND_B: return
             (x & "B"_mst).If(y << "W"_mst) | // B=B_x*W_y
             ((x | y) & "o"_mst).If((x | y) << "z"_mst) | // o=o_x*z_y+z_x*o_y
             (x & "n"_mst) | (y & "n"_mst).If(x << "z"_mst) | // n=n_x+z_x*n_y
@@ -161,7 +161,7 @@ Type ComputeType(NodeType nodetype, Type x, Type y, Type z, const std::vector<Ty
                 ((x << "h"_mst) && (y << "g"_mst)) ||
                 ((x << "i"_mst) && (y << "j"_mst)) ||
                 ((x << "j"_mst) && (y << "i"_mst)))); // k=k_x*k_y*!(g_x*h_y + h_x*g_y + i_x*j_y + j_x*i_y)
-        case NodeType::OR_B: return
+        case Fragment::OR_B: return
             "B"_mst.If(x << "Bd"_mst && y << "Wd"_mst) | // B=B_x*d_x*W_x*d_y
             ((x | y) & "o"_mst).If((x | y) << "z"_mst) | // o=o_x*z_y+z_x*o_y
             (x & y & "m"_mst).If((x | y) << "s"_mst && (x & y) << "e"_mst) | // m=m_x*m_y*e_x*e_y*(s_x+s_y)
@@ -169,7 +169,7 @@ Type ComputeType(NodeType nodetype, Type x, Type y, Type z, const std::vector<Ty
             "dux"_mst | // d, u, x
             ((x | y) & "ghij"_mst) | // g=g_x+g_y, h=h_x+h_y, i=i_x+i_y, j=j_x+j_y
             (x & y & "k"_mst); // k=k_x*k_y
-        case NodeType::OR_D: return
+        case Fragment::OR_D: return
             (y & "B"_mst).If(x << "Bdu"_mst) | // B=B_y*B_x*d_x*u_x
             (x & "o"_mst).If(y << "z"_mst) | // o=o_x*z_y
             (x & y & "m"_mst).If(x << "e"_mst && (x | y) << "s"_mst) | // m=m_x*m_y*e_x*(s_x+s_y)
@@ -178,7 +178,7 @@ Type ComputeType(NodeType nodetype, Type x, Type y, Type z, const std::vector<Ty
             "x"_mst | // x
             ((x | y) & "ghij"_mst) | // g=g_x+g_y, h=h_x+h_y, i=i_x+i_y, j=j_x+j_y
             (x & y & "k"_mst); // k=k_x*k_y
-        case NodeType::OR_C: return
+        case Fragment::OR_C: return
             (y & "V"_mst).If(x << "Bdu"_mst) | // V=V_y*B_x*u_x*d_x
             (x & "o"_mst).If(y << "z"_mst) | // o=o_x*z_y
             (x & y & "m"_mst).If(x << "e"_mst && (x | y) << "s"_mst) | // m=m_x*m_y*e_x*(s_x+s_y)
@@ -186,7 +186,7 @@ Type ComputeType(NodeType nodetype, Type x, Type y, Type z, const std::vector<Ty
             "fx"_mst | // f, x
             ((x | y) & "ghij"_mst) | // g=g_x+g_y, h=h_x+h_y, i=i_x+i_y, j=j_x+j_y
             (x & y & "k"_mst); // k=k_x*k_y
-        case NodeType::OR_I: return
+        case Fragment::OR_I: return
             (x & y & "VBKufs"_mst) | // V=V_x*V_y, B=B_x*B_y, K=K_x*K_y, u=u_x*u_y, f=f_x*f_y, s=s_x*s_y
             "o"_mst.If((x & y) << "z"_mst) | // o=z_x*z_y
             ((x | y) & "e"_mst).If((x | y) << "f"_mst) | // e=e_x*f_y+f_x*e_y
@@ -195,7 +195,7 @@ Type ComputeType(NodeType nodetype, Type x, Type y, Type z, const std::vector<Ty
             "x"_mst | // x
             ((x | y) & "ghij"_mst) | // g=g_x+g_y, h=h_x+h_y, i=i_x+i_y, j=j_x+j_y
             (x & y & "k"_mst); // k=k_x*k_y
-        case NodeType::ANDOR: return
+        case Fragment::ANDOR: return
             (y & z & "BKV"_mst).If(x << "Bdu"_mst) | // B=B_x*d_x*u_x*B_y*B_z, K=B_x*d_x*u_x*K_y*K_z, V=B_x*d_x*u_x*V_y*V_z
             (x & y & z & "z"_mst) | // z=z_x*z_y*z_z
             ((x | (y & z)) & "o"_mst).If((x | (y & z)) << "z"_mst) | // o=o_x*z_y*z_z+z_x*o_y*o_z
@@ -212,8 +212,8 @@ Type ComputeType(NodeType nodetype, Type x, Type y, Type z, const std::vector<Ty
                 ((x << "h"_mst) && (y << "g"_mst)) ||
                 ((x << "i"_mst) && (y << "j"_mst)) ||
                 ((x << "j"_mst) && (y << "i"_mst)))); // k=k_x*k_y*k_z* !(g_x*h_y + h_x*g_y + i_x*j_y + j_x*i_y)
-        case NodeType::MULTI: return "Bnudemsk"_mst;
-        case NodeType::THRESH: {
+        case Fragment::MULTI: return "Bnudemsk"_mst;
+        case Fragment::THRESH: {
             bool all_e = true;
             bool all_m = true;
             uint32_t args = 0;
@@ -249,34 +249,34 @@ Type ComputeType(NodeType nodetype, Type x, Type y, Type z, const std::vector<Ty
     return ""_mst;
 }
 
-size_t ComputeScriptLen(NodeType nodetype, Type sub0typ, size_t subsize, uint32_t k, size_t n_subs, size_t n_keys) {
+size_t ComputeScriptLen(Fragment nodetype, Type sub0typ, size_t subsize, uint32_t k, size_t n_subs, size_t n_keys) {
     switch (nodetype) {
-        case NodeType::PK_K: return subsize + 34;
-        case NodeType::PK_H: return subsize + 3 + 21;
-        case NodeType::OLDER: return subsize + 1 + BuildScript(k).size();
-        case NodeType::AFTER: return subsize + 1 + BuildScript(k).size();
-        case NodeType::HASH256: return subsize + 4 + 2 + 33;
-        case NodeType::HASH160: return subsize + 4 + 2 + 21;
-        case NodeType::SHA256: return subsize + 4 + 2 + 33;
-        case NodeType::RIPEMD160: return subsize + 4 + 2 + 21;
-        case NodeType::WRAP_A: return subsize + 2;
-        case NodeType::WRAP_S: return subsize + 1;
-        case NodeType::WRAP_C: return subsize + 1;
-        case NodeType::WRAP_D: return subsize + 3;
-        case NodeType::WRAP_V: return subsize + (sub0typ << "x"_mst);
-        case NodeType::WRAP_J: return subsize + 4;
-        case NodeType::WRAP_N: return subsize + 1;
-        case NodeType::JUST_1: return 1;
-        case NodeType::JUST_0: return 1;
-        case NodeType::AND_V: return subsize;
-        case NodeType::AND_B: return subsize + 1;
-        case NodeType::OR_B: return subsize + 1;
-        case NodeType::OR_D: return subsize + 3;
-        case NodeType::OR_C: return subsize + 2;
-        case NodeType::OR_I: return subsize + 3;
-        case NodeType::ANDOR: return subsize + 3;
-        case NodeType::THRESH: return subsize + n_subs + BuildScript(k).size();
-        case NodeType::MULTI: return subsize + 3 + (n_keys > 16) + (k > 16) + 34 * n_keys;
+        case Fragment::JUST_1:
+        case Fragment::JUST_0: return 1;
+        case Fragment::PK_K: return 34;
+        case Fragment::PK_H: return 3 + 21;
+        case Fragment::OLDER: return 1 + BuildScript(k).size();
+        case Fragment::AFTER: return 1 + BuildScript(k).size();
+        case Fragment::HASH256:
+        case Fragment::SHA256: return 4 + 2 + 33;
+        case Fragment::HASH160:
+        case Fragment::RIPEMD160: return 4 + 2 + 21;
+        case Fragment::MULTI: return 3 + (n_keys > 16) + (k > 16) + 34 * n_keys;
+        case Fragment::AND_V: return subsize;
+        case Fragment::WRAP_V: return subsize + (sub0typ << "x"_mst);
+        case Fragment::WRAP_S:
+        case Fragment::WRAP_C:
+        case Fragment::WRAP_N:
+        case Fragment::AND_B:
+        case Fragment::OR_B: return subsize + 1;
+        case Fragment::WRAP_A:
+        case Fragment::OR_C: return subsize + 2;
+        case Fragment::WRAP_D:
+        case Fragment::OR_D:
+        case Fragment::OR_I:
+        case Fragment::ANDOR: return subsize + 3;
+        case Fragment::WRAP_J: return subsize + 4;
+        case Fragment::THRESH: return subsize + n_subs + BuildScript(k).size();
     }
     assert(false);
     return 0;

--- a/bitcoin/script/miniscript.h
+++ b/bitcoin/script/miniscript.h
@@ -16,13 +16,13 @@
 #include <assert.h>
 
 #include <policy/policy.h>
+#include <primitives/transaction.h>
 #include <script/script.h>
 #include <span.h>
 #include <util/spanparsing.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/vector.h>
-#include <primitives/transaction.h>
 
 namespace miniscript {
 
@@ -107,8 +107,8 @@ namespace miniscript {
  * user expects.
  * - "g" Whether the branch contains a relative time timelock
  * - "h" Whether the branch contains a relative height timelock
- * - "i" Whether the branch contains a absolute time timelock
- * - "j" Whether the branch contains a absolute time heightlock
+ * - "i" Whether the branch contains an absolute time timelock
+ * - "j" Whether the branch contains an absolute height timelock
  * - "k"
  *   - Whether all satisfactions of this expression don't contain a mix of heightlock and timelock
  *     of the same type.
@@ -187,7 +187,7 @@ template<typename Key, typename... Args>
 NodeRef<Key> MakeNodeRef(Args&&... args) { return std::make_shared<const Node<Key>>(std::forward<Args>(args)...); }
 
 //! The different node types in miniscript.
-enum class NodeType {
+enum class Fragment {
     JUST_0,    //!< OP_0
     JUST_1,    //!< OP_1
     PK_K,      //!< [key]
@@ -229,10 +229,10 @@ enum class Availability {
 namespace internal {
 
 //! Helper function for Node::CalcType.
-Type ComputeType(NodeType nodetype, Type x, Type y, Type z, const std::vector<Type>& sub_types, uint32_t k, size_t data_size, size_t n_subs, size_t n_keys);
+Type ComputeType(Fragment nodetype, Type x, Type y, Type z, const std::vector<Type>& sub_types, uint32_t k, size_t data_size, size_t n_subs, size_t n_keys);
 
 //! Helper function for Node::CalcScriptLen.
-size_t ComputeScriptLen(NodeType nodetype, Type sub0typ, size_t subsize, uint32_t k, size_t n_subs, size_t n_keys);
+size_t ComputeScriptLen(Fragment nodetype, Type sub0typ, size_t subsize, uint32_t k, size_t n_subs, size_t n_keys);
 
 //! A helper sanitizer/checker for the output of CalcType.
 Type SanitizeType(Type x);
@@ -308,13 +308,13 @@ struct MaxInt {
 
 struct Ops {
     //! Non-push opcodes.
-    uint32_t stat;
+    uint32_t count;
     //! Number of keys in possibly executed OP_CHECKMULTISIG(VERIFY)s to satisfy.
     MaxInt<uint32_t> sat;
     //! Number of keys in possibly executed OP_CHECKMULTISIG(VERIFY)s to dissatisfy.
     MaxInt<uint32_t> dsat;
 
-    Ops(uint32_t in_stat, MaxInt<uint32_t> in_sat, MaxInt<uint32_t> in_dsat) : stat(in_stat), sat(in_sat), dsat(in_dsat) {};
+    Ops(uint32_t in_count, MaxInt<uint32_t> in_sat, MaxInt<uint32_t> in_dsat) : count(in_count), sat(in_sat), dsat(in_dsat) {};
 };
 
 struct StackSize {
@@ -332,7 +332,7 @@ struct StackSize {
 template<typename Key>
 struct Node {
     //! What node type this node is.
-    const NodeType nodetype;
+    const Fragment nodetype;
     //! The k parameter (time for OLDER/AFTER, threshold for THRESH(_M))
     const uint32_t k = 0;
     //! The keys used by this expression (only for PK_K/PK_H/MULTI)
@@ -424,7 +424,7 @@ private:
             if (stack.back().expanded < node.subs.size()) {
                 /* We encounter a tree node with at least one unexpanded child.
                  * Expand it. By the time we hit this node again, the result of
-                 * that child (and all earlier children) will be on the stack. */
+                 * that child (and all earlier children) will be at the end of `results`. */
                 size_t child_index = stack.back().expanded++;
                 State child_state = downfn(stack.back().state, node, child_index);
                 stack.emplace_back(*node.subs[child_index], 0, std::move(child_state));
@@ -480,12 +480,12 @@ private:
     Type CalcType() const {
         using namespace internal;
 
-        // THRESH has a variable number of subexpression
+        // THRESH has a variable number of subexpressions
         std::vector<Type> sub_types;
-        if (nodetype == NodeType::THRESH) {
+        if (nodetype == Fragment::THRESH) {
             for (const auto& sub : subs) sub_types.push_back(sub->GetType());
         }
-        // All other nodes than THRESH can be computed just from the types of the 0-3 subexpexpressions.
+        // All other nodes than THRESH can be computed just from the types of the 0-3 subexpressions.
         Type x = subs.size() > 0 ? subs[0]->GetType() : ""_mst;
         Type y = subs.size() > 1 ? subs[1]->GetType() : ""_mst;
         Type z = subs.size() > 2 ? subs[2]->GetType() : ""_mst;
@@ -502,55 +502,55 @@ public:
         // by an OP_VERIFY (which may need to be combined with the last script opcode).
         auto downfn = [](bool verify, const Node& node, size_t index) {
             // For WRAP_V, the subexpression is certainly followed by OP_VERIFY.
-            if (node.nodetype == NodeType::WRAP_V) return true;
+            if (node.nodetype == Fragment::WRAP_V) return true;
             // The subexpression of WRAP_S, and the last subexpression of AND_V
             // inherit the followed-by-OP_VERIFY property from the parent.
-            if (node.nodetype == NodeType::WRAP_S ||
-                (node.nodetype == NodeType::AND_V && index == 1)) return verify;
+            if (node.nodetype == Fragment::WRAP_S ||
+                (node.nodetype == Fragment::AND_V && index == 1)) return verify;
             return false;
         };
         // The upward function computes for a node, given its followed-by-OP_VERIFY status
         // and the CScripts of its child nodes, the CScript of the node.
         auto upfn = [&ctx](bool verify, const Node& node, Span<CScript> subs) -> CScript {
             switch (node.nodetype) {
-                case NodeType::PK_K: return BuildScript(ctx.ToPKBytes(node.keys[0]));
-                case NodeType::PK_H: return BuildScript(OP_DUP, OP_HASH160, ctx.ToPKHBytes(node.keys[0]), OP_EQUALVERIFY);
-                case NodeType::OLDER: return BuildScript(node.k, OP_CHECKSEQUENCEVERIFY);
-                case NodeType::AFTER: return BuildScript(node.k, OP_CHECKLOCKTIMEVERIFY);
-                case NodeType::SHA256: return BuildScript(OP_SIZE, 32, OP_EQUALVERIFY, OP_SHA256, node.data, verify ? OP_EQUALVERIFY : OP_EQUAL);
-                case NodeType::RIPEMD160: return BuildScript(OP_SIZE, 32, OP_EQUALVERIFY, OP_RIPEMD160, node.data, verify ? OP_EQUALVERIFY : OP_EQUAL);
-                case NodeType::HASH256: return BuildScript(OP_SIZE, 32, OP_EQUALVERIFY, OP_HASH256, node.data, verify ? OP_EQUALVERIFY : OP_EQUAL);
-                case NodeType::HASH160: return BuildScript(OP_SIZE, 32, OP_EQUALVERIFY, OP_HASH160, node.data, verify ? OP_EQUALVERIFY : OP_EQUAL);
-                case NodeType::WRAP_A: return BuildScript(OP_TOALTSTACK, subs[0], OP_FROMALTSTACK);
-                case NodeType::WRAP_S: return BuildScript(OP_SWAP, subs[0]);
-                case NodeType::WRAP_C: return BuildScript(std::move(subs[0]), verify ? OP_CHECKSIGVERIFY : OP_CHECKSIG);
-                case NodeType::WRAP_D: return BuildScript(OP_DUP, OP_IF, subs[0], OP_ENDIF);
-                case NodeType::WRAP_V: {
+                case Fragment::PK_K: return BuildScript(ctx.ToPKBytes(node.keys[0]));
+                case Fragment::PK_H: return BuildScript(OP_DUP, OP_HASH160, ctx.ToPKHBytes(node.keys[0]), OP_EQUALVERIFY);
+                case Fragment::OLDER: return BuildScript(node.k, OP_CHECKSEQUENCEVERIFY);
+                case Fragment::AFTER: return BuildScript(node.k, OP_CHECKLOCKTIMEVERIFY);
+                case Fragment::SHA256: return BuildScript(OP_SIZE, 32, OP_EQUALVERIFY, OP_SHA256, node.data, verify ? OP_EQUALVERIFY : OP_EQUAL);
+                case Fragment::RIPEMD160: return BuildScript(OP_SIZE, 32, OP_EQUALVERIFY, OP_RIPEMD160, node.data, verify ? OP_EQUALVERIFY : OP_EQUAL);
+                case Fragment::HASH256: return BuildScript(OP_SIZE, 32, OP_EQUALVERIFY, OP_HASH256, node.data, verify ? OP_EQUALVERIFY : OP_EQUAL);
+                case Fragment::HASH160: return BuildScript(OP_SIZE, 32, OP_EQUALVERIFY, OP_HASH160, node.data, verify ? OP_EQUALVERIFY : OP_EQUAL);
+                case Fragment::WRAP_A: return BuildScript(OP_TOALTSTACK, subs[0], OP_FROMALTSTACK);
+                case Fragment::WRAP_S: return BuildScript(OP_SWAP, subs[0]);
+                case Fragment::WRAP_C: return BuildScript(std::move(subs[0]), verify ? OP_CHECKSIGVERIFY : OP_CHECKSIG);
+                case Fragment::WRAP_D: return BuildScript(OP_DUP, OP_IF, subs[0], OP_ENDIF);
+                case Fragment::WRAP_V: {
                     if (node.subs[0]->GetType() << "x"_mst) {
                         return BuildScript(std::move(subs[0]), OP_VERIFY);
                     } else {
                         return std::move(subs[0]);
                     }
                 }
-                case NodeType::WRAP_J: return BuildScript(OP_SIZE, OP_0NOTEQUAL, OP_IF, subs[0], OP_ENDIF);
-                case NodeType::WRAP_N: return BuildScript(std::move(subs[0]), OP_0NOTEQUAL);
-                case NodeType::JUST_1: return BuildScript(OP_1);
-                case NodeType::JUST_0: return BuildScript(OP_0);
-                case NodeType::AND_V: return BuildScript(std::move(subs[0]), subs[1]);
-                case NodeType::AND_B: return BuildScript(std::move(subs[0]), subs[1], OP_BOOLAND);
-                case NodeType::OR_B: return BuildScript(std::move(subs[0]), subs[1], OP_BOOLOR);
-                case NodeType::OR_D: return BuildScript(std::move(subs[0]), OP_IFDUP, OP_NOTIF, subs[1], OP_ENDIF);
-                case NodeType::OR_C: return BuildScript(std::move(subs[0]), OP_NOTIF, subs[1], OP_ENDIF);
-                case NodeType::OR_I: return BuildScript(OP_IF, subs[0], OP_ELSE, subs[1], OP_ENDIF);
-                case NodeType::ANDOR: return BuildScript(std::move(subs[0]), OP_NOTIF, subs[2], OP_ELSE, subs[1], OP_ENDIF);
-                case NodeType::MULTI: {
+                case Fragment::WRAP_J: return BuildScript(OP_SIZE, OP_0NOTEQUAL, OP_IF, subs[0], OP_ENDIF);
+                case Fragment::WRAP_N: return BuildScript(std::move(subs[0]), OP_0NOTEQUAL);
+                case Fragment::JUST_1: return BuildScript(OP_1);
+                case Fragment::JUST_0: return BuildScript(OP_0);
+                case Fragment::AND_V: return BuildScript(std::move(subs[0]), subs[1]);
+                case Fragment::AND_B: return BuildScript(std::move(subs[0]), subs[1], OP_BOOLAND);
+                case Fragment::OR_B: return BuildScript(std::move(subs[0]), subs[1], OP_BOOLOR);
+                case Fragment::OR_D: return BuildScript(std::move(subs[0]), OP_IFDUP, OP_NOTIF, subs[1], OP_ENDIF);
+                case Fragment::OR_C: return BuildScript(std::move(subs[0]), OP_NOTIF, subs[1], OP_ENDIF);
+                case Fragment::OR_I: return BuildScript(OP_IF, subs[0], OP_ELSE, subs[1], OP_ENDIF);
+                case Fragment::ANDOR: return BuildScript(std::move(subs[0]), OP_NOTIF, subs[2], OP_ELSE, subs[1], OP_ENDIF);
+                case Fragment::MULTI: {
                     CScript script = BuildScript(node.k);
                     for (const auto& key : node.keys) {
                         script = BuildScript(std::move(script), ctx.ToPKBytes(key));
                     }
                     return BuildScript(std::move(script), node.keys.size(), verify ? OP_CHECKMULTISIGVERIFY : OP_CHECKMULTISIG);
                 }
-                case NodeType::THRESH: {
+                case Fragment::THRESH: {
                     CScript script = std::move(subs[0]);
                     for (size_t i = 1; i < subs.size(); ++i) {
                         script = BuildScript(std::move(script), subs[i], OP_ADD);
@@ -570,13 +570,13 @@ public:
         // the TreeEvalMaybe algorithm. The State is a boolean: whether the parent node is a
         // wrapper. If so, non-wrapper expressions must be prefixed with a ":".
         auto downfn = [](bool, const Node& node, size_t) {
-            return (node.nodetype == NodeType::WRAP_A || node.nodetype == NodeType::WRAP_S ||
-                    node.nodetype == NodeType::WRAP_D || node.nodetype == NodeType::WRAP_V ||
-                    node.nodetype == NodeType::WRAP_J || node.nodetype == NodeType::WRAP_N ||
-                    node.nodetype == NodeType::WRAP_C ||
-                    (node.nodetype == NodeType::AND_V && node.subs[1]->nodetype == NodeType::JUST_1) ||
-                    (node.nodetype == NodeType::OR_I && node.subs[0]->nodetype == NodeType::JUST_0) ||
-                    (node.nodetype == NodeType::OR_I && node.subs[1]->nodetype == NodeType::JUST_0));
+            return (node.nodetype == Fragment::WRAP_A || node.nodetype == Fragment::WRAP_S ||
+                    node.nodetype == Fragment::WRAP_D || node.nodetype == Fragment::WRAP_V ||
+                    node.nodetype == Fragment::WRAP_J || node.nodetype == Fragment::WRAP_N ||
+                    node.nodetype == Fragment::WRAP_C ||
+                    (node.nodetype == Fragment::AND_V && node.subs[1]->nodetype == Fragment::JUST_1) ||
+                    (node.nodetype == Fragment::OR_I && node.subs[0]->nodetype == Fragment::JUST_0) ||
+                    (node.nodetype == Fragment::OR_I && node.subs[1]->nodetype == Fragment::JUST_0));
         };
         // The upward function computes for a node, given whether its parent is a wrapper,
         // and the string representations of its child nodes, the string representation of the node.
@@ -584,66 +584,66 @@ public:
             std::string ret = wrapped ? ":" : "";
 
             switch (node.nodetype) {
-                case NodeType::WRAP_A: return "a" + std::move(subs[0]);
-                case NodeType::WRAP_S: return "s" + std::move(subs[0]);
-                case NodeType::WRAP_C:
-                    if (node.subs[0]->nodetype == NodeType::PK_K) {
+                case Fragment::WRAP_A: return "a" + std::move(subs[0]);
+                case Fragment::WRAP_S: return "s" + std::move(subs[0]);
+                case Fragment::WRAP_C:
+                    if (node.subs[0]->nodetype == Fragment::PK_K) {
                         // pk(K) is syntactic sugar for c:pk_k(K)
                         std::string key_str;
                         if (!ctx.ToString(node.subs[0]->keys[0], key_str)) return {};
                         return std::move(ret) + "pk(" + std::move(key_str) + ")";
                     }
-                    if (node.subs[0]->nodetype == NodeType::PK_H) {
+                    if (node.subs[0]->nodetype == Fragment::PK_H) {
                         // pkh(K) is syntactic sugar for c:pk_h(K)
                         std::string key_str;
                         if (!ctx.ToString(node.subs[0]->keys[0], key_str)) return {};
                         return std::move(ret) + "pkh(" + std::move(key_str) + ")";
                     }
                     return "c" + std::move(subs[0]);
-                case NodeType::WRAP_D: return "d" + std::move(subs[0]);
-                case NodeType::WRAP_V: return "v" + std::move(subs[0]);
-                case NodeType::WRAP_J: return "j" + std::move(subs[0]);
-                case NodeType::WRAP_N: return "n" + std::move(subs[0]);
-                case NodeType::AND_V:
+                case Fragment::WRAP_D: return "d" + std::move(subs[0]);
+                case Fragment::WRAP_V: return "v" + std::move(subs[0]);
+                case Fragment::WRAP_J: return "j" + std::move(subs[0]);
+                case Fragment::WRAP_N: return "n" + std::move(subs[0]);
+                case Fragment::AND_V:
                     // t:X is syntactic sugar for and_v(X,1).
-                    if (node.subs[1]->nodetype == NodeType::JUST_1) return "t" + std::move(subs[0]);
+                    if (node.subs[1]->nodetype == Fragment::JUST_1) return "t" + std::move(subs[0]);
                     break;
-                case NodeType::OR_I:
-                    if (node.subs[0]->nodetype == NodeType::JUST_0) return "l" + std::move(subs[1]);
-                    if (node.subs[1]->nodetype == NodeType::JUST_0) return "u" + std::move(subs[0]);
+                case Fragment::OR_I:
+                    if (node.subs[0]->nodetype == Fragment::JUST_0) return "l" + std::move(subs[1]);
+                    if (node.subs[1]->nodetype == Fragment::JUST_0) return "u" + std::move(subs[0]);
                     break;
                 default: break;
             }
             switch (node.nodetype) {
-                case NodeType::PK_K: {
+                case Fragment::PK_K: {
                     std::string key_str;
                     if (!ctx.ToString(node.keys[0], key_str)) return {};
                     return std::move(ret) + "pk_k(" + std::move(key_str) + ")";
                 }
-                case NodeType::PK_H: {
+                case Fragment::PK_H: {
                     std::string key_str;
                     if (!ctx.ToString(node.keys[0], key_str)) return {};
                     return std::move(ret) + "pk_h(" + std::move(key_str) + ")";
                 }
-                case NodeType::AFTER: return std::move(ret) + "after(" + ::ToString(node.k) + ")";
-                case NodeType::OLDER: return std::move(ret) + "older(" + ::ToString(node.k) + ")";
-                case NodeType::HASH256: return std::move(ret) + "hash256(" + HexStr(node.data) + ")";
-                case NodeType::HASH160: return std::move(ret) + "hash160(" + HexStr(node.data) + ")";
-                case NodeType::SHA256: return std::move(ret) + "sha256(" + HexStr(node.data) + ")";
-                case NodeType::RIPEMD160: return std::move(ret) + "ripemd160(" + HexStr(node.data) + ")";
-                case NodeType::JUST_1: return std::move(ret) + "1";
-                case NodeType::JUST_0: return std::move(ret) + "0";
-                case NodeType::AND_V: return std::move(ret) + "and_v(" + std::move(subs[0]) + "," + std::move(subs[1]) + ")";
-                case NodeType::AND_B: return std::move(ret) + "and_b(" + std::move(subs[0]) + "," + std::move(subs[1]) + ")";
-                case NodeType::OR_B: return std::move(ret) + "or_b(" + std::move(subs[0]) + "," + std::move(subs[1]) + ")";
-                case NodeType::OR_D: return std::move(ret) + "or_d(" + std::move(subs[0]) + "," + std::move(subs[1]) + ")";
-                case NodeType::OR_C: return std::move(ret) + "or_c(" + std::move(subs[0]) + "," + std::move(subs[1]) + ")";
-                case NodeType::OR_I: return std::move(ret) + "or_i(" + std::move(subs[0]) + "," + std::move(subs[1]) + ")";
-                case NodeType::ANDOR:
+                case Fragment::AFTER: return std::move(ret) + "after(" + ::ToString(node.k) + ")";
+                case Fragment::OLDER: return std::move(ret) + "older(" + ::ToString(node.k) + ")";
+                case Fragment::HASH256: return std::move(ret) + "hash256(" + HexStr(node.data) + ")";
+                case Fragment::HASH160: return std::move(ret) + "hash160(" + HexStr(node.data) + ")";
+                case Fragment::SHA256: return std::move(ret) + "sha256(" + HexStr(node.data) + ")";
+                case Fragment::RIPEMD160: return std::move(ret) + "ripemd160(" + HexStr(node.data) + ")";
+                case Fragment::JUST_1: return std::move(ret) + "1";
+                case Fragment::JUST_0: return std::move(ret) + "0";
+                case Fragment::AND_V: return std::move(ret) + "and_v(" + std::move(subs[0]) + "," + std::move(subs[1]) + ")";
+                case Fragment::AND_B: return std::move(ret) + "and_b(" + std::move(subs[0]) + "," + std::move(subs[1]) + ")";
+                case Fragment::OR_B: return std::move(ret) + "or_b(" + std::move(subs[0]) + "," + std::move(subs[1]) + ")";
+                case Fragment::OR_D: return std::move(ret) + "or_d(" + std::move(subs[0]) + "," + std::move(subs[1]) + ")";
+                case Fragment::OR_C: return std::move(ret) + "or_c(" + std::move(subs[0]) + "," + std::move(subs[1]) + ")";
+                case Fragment::OR_I: return std::move(ret) + "or_i(" + std::move(subs[0]) + "," + std::move(subs[1]) + ")";
+                case Fragment::ANDOR:
                     // and_n(X,Y) is syntactic sugar for andor(X,Y,0).
-                    if (node.subs[2]->nodetype == NodeType::JUST_0) return std::move(ret) + "and_n(" + std::move(subs[0]) + "," + std::move(subs[1]) + ")";
+                    if (node.subs[2]->nodetype == Fragment::JUST_0) return std::move(ret) + "and_n(" + std::move(subs[0]) + "," + std::move(subs[1]) + ")";
                     return std::move(ret) + "andor(" + std::move(subs[0]) + "," + std::move(subs[1]) + "," + std::move(subs[2]) + ")";
-                case NodeType::MULTI: {
+                case Fragment::MULTI: {
                     auto str = std::move(ret) + "multi(" + ::ToString(node.k);
                     for (const auto& key : node.keys) {
                         std::string key_str;
@@ -652,7 +652,7 @@ public:
                     }
                     return std::move(str) + ")";
                 }
-                case NodeType::THRESH: {
+                case Fragment::THRESH: {
                     auto str = std::move(ret) + "thresh(" + ::ToString(node.k);
                     for (auto& sub : subs) {
                         str += "," + std::move(sub);
@@ -669,46 +669,74 @@ public:
         return res.has_value();
     }
 
-private:
     internal::Ops CalcOps() const {
         switch (nodetype) {
-            case NodeType::PK_K: return {0, 0, 0};
-            case NodeType::PK_H: return {3, 0, 0};
-            case NodeType::OLDER: return {1, 0, {}};
-            case NodeType::AFTER: return {1, 0, {}};
-            case NodeType::SHA256: return {4, 0, {}};
-            case NodeType::RIPEMD160: return {4, 0, {}};
-            case NodeType::HASH256: return {4, 0, {}};
-            case NodeType::HASH160: return {4, 0, {}};
-            case NodeType::AND_V: return {subs[0]->ops.stat + subs[1]->ops.stat, subs[0]->ops.sat + subs[1]->ops.sat, {}};
-            case NodeType::AND_B: return {1 + subs[0]->ops.stat + subs[1]->ops.stat, subs[0]->ops.sat + subs[1]->ops.sat, subs[0]->ops.dsat + subs[1]->ops.dsat};
-            case NodeType::OR_B: return {1 + subs[0]->ops.stat + subs[1]->ops.stat, Choose(subs[0]->ops.sat + subs[1]->ops.dsat, subs[1]->ops.sat + subs[0]->ops.dsat), subs[0]->ops.dsat + subs[1]->ops.dsat};
-            case NodeType::OR_D: return {3 + subs[0]->ops.stat + subs[1]->ops.stat, Choose(subs[0]->ops.sat, subs[1]->ops.sat + subs[0]->ops.dsat), subs[0]->ops.dsat + subs[1]->ops.dsat};
-            case NodeType::OR_C: return {2 + subs[0]->ops.stat + subs[1]->ops.stat, Choose(subs[0]->ops.sat, subs[1]->ops.sat + subs[0]->ops.dsat), {}};
-            case NodeType::OR_I: return {3 + subs[0]->ops.stat + subs[1]->ops.stat, Choose(subs[0]->ops.sat, subs[1]->ops.sat), Choose(subs[0]->ops.dsat, subs[1]->ops.dsat)};
-            case NodeType::ANDOR: return {3 + subs[0]->ops.stat + subs[1]->ops.stat + subs[2]->ops.stat, Choose(subs[1]->ops.sat + subs[0]->ops.sat, subs[0]->ops.dsat + subs[2]->ops.sat), subs[0]->ops.dsat + subs[2]->ops.dsat};
-            case NodeType::MULTI: return {1, (uint32_t)keys.size(), (uint32_t)keys.size()};
-            case NodeType::WRAP_A: return {2 + subs[0]->ops.stat, subs[0]->ops.sat, subs[0]->ops.dsat};
-            case NodeType::WRAP_S: return {1 + subs[0]->ops.stat, subs[0]->ops.sat, subs[0]->ops.dsat};
-            case NodeType::WRAP_C: return {1 + subs[0]->ops.stat, subs[0]->ops.sat, subs[0]->ops.dsat};
-            case NodeType::WRAP_D: return {3 + subs[0]->ops.stat, subs[0]->ops.sat, 0};
-            case NodeType::WRAP_V: return {subs[0]->ops.stat + (subs[0]->GetType() << "x"_mst), subs[0]->ops.sat, {}};
-            case NodeType::WRAP_J: return {4 + subs[0]->ops.stat, subs[0]->ops.sat, 0};
-            case NodeType::WRAP_N: return {1 + subs[0]->ops.stat, subs[0]->ops.sat, subs[0]->ops.dsat};
-            case NodeType::JUST_1: return {0, 0, {}};
-            case NodeType::JUST_0: return {0, {}, 0};
-            case NodeType::THRESH: {
-                uint32_t stat = 0;
+            case Fragment::JUST_1: return {0, 0, {}};
+            case Fragment::JUST_0: return {0, {}, 0};
+            case Fragment::PK_K: return {0, 0, 0};
+            case Fragment::PK_H: return {3, 0, 0};
+            case Fragment::OLDER:
+            case Fragment::AFTER: return {1, 0, {}};
+            case Fragment::SHA256:
+            case Fragment::RIPEMD160:
+            case Fragment::HASH256:
+            case Fragment::HASH160: return {4, 0, {}};
+            case Fragment::AND_V: return {subs[0]->ops.count + subs[1]->ops.count, subs[0]->ops.sat + subs[1]->ops.sat, {}};
+            case Fragment::AND_B: {
+                const uint32_t count{1 + subs[0]->ops.count + subs[1]->ops.count};
+                const internal::MaxInt<uint32_t> sat{subs[0]->ops.sat + subs[1]->ops.sat};
+                const internal::MaxInt<uint32_t> dsat{subs[0]->ops.dsat + subs[1]->ops.dsat};
+                return {count, sat, dsat};
+            }
+            case Fragment::OR_B: {
+                const uint32_t count{1 + subs[0]->ops.count + subs[1]->ops.count};
+                const internal::MaxInt<uint32_t> sat{Choose(subs[0]->ops.sat + subs[1]->ops.dsat, subs[1]->ops.sat + subs[0]->ops.dsat)};
+                const internal::MaxInt<uint32_t> dsat{subs[0]->ops.dsat + subs[1]->ops.dsat};
+                return {count, sat, dsat};
+            }
+            case Fragment::OR_D: {
+                const uint32_t count{3 + subs[0]->ops.count + subs[1]->ops.count};
+                const internal::MaxInt<uint32_t> sat{Choose(subs[0]->ops.sat, subs[1]->ops.sat + subs[0]->ops.dsat)};
+                const internal::MaxInt<uint32_t> dsat{subs[0]->ops.dsat + subs[1]->ops.dsat};
+                return {count, sat, dsat};
+            }
+            case Fragment::OR_C: {
+                const uint32_t count{2 + subs[0]->ops.count + subs[1]->ops.count};
+                const internal::MaxInt<uint32_t> sat{Choose(subs[0]->ops.sat, subs[1]->ops.sat + subs[0]->ops.dsat)};
+                return {count, sat, {}};
+            }
+            case Fragment::OR_I: {
+                const uint32_t count{3 + subs[0]->ops.count + subs[1]->ops.count};
+                const internal::MaxInt<uint32_t> sat{Choose(subs[0]->ops.sat, subs[1]->ops.sat)};
+                const internal::MaxInt<uint32_t> dsat{Choose(subs[0]->ops.dsat, subs[1]->ops.dsat)};
+                return {count, sat, dsat};
+            }
+            case Fragment::ANDOR: {
+                const uint32_t count{3 + subs[0]->ops.count + subs[1]->ops.count + subs[2]->ops.count};
+                const internal::MaxInt<uint32_t> sat{Choose(subs[1]->ops.sat + subs[0]->ops.sat, subs[0]->ops.dsat + subs[2]->ops.sat)};
+                const internal::MaxInt<uint32_t> dsat{subs[0]->ops.dsat + subs[2]->ops.dsat};
+                return {count, sat, dsat};
+            }
+            case Fragment::MULTI: return {1, (uint32_t)keys.size(), (uint32_t)keys.size()};
+            case Fragment::WRAP_S:
+            case Fragment::WRAP_C:
+            case Fragment::WRAP_N: return {1 + subs[0]->ops.count, subs[0]->ops.sat, subs[0]->ops.dsat};
+            case Fragment::WRAP_A: return {2 + subs[0]->ops.count, subs[0]->ops.sat, subs[0]->ops.dsat};
+            case Fragment::WRAP_D: return {3 + subs[0]->ops.count, subs[0]->ops.sat, 0};
+            case Fragment::WRAP_J: return {4 + subs[0]->ops.count, subs[0]->ops.sat, 0};
+            case Fragment::WRAP_V: return {subs[0]->ops.count + (subs[0]->GetType() << "x"_mst), subs[0]->ops.sat, {}};
+            case Fragment::THRESH: {
+                uint32_t count = 0;
                 auto sats = Vector(internal::MaxInt<uint32_t>(0));
                 for (const auto& sub : subs) {
-                    stat += sub->ops.stat + 1;
+                    count += sub->ops.count + 1;
                     auto next_sats = Vector(sats[0] + sub->ops.dsat);
                     for (size_t j = 1; j < sats.size(); ++j) next_sats.push_back(Choose(sats[j] + sub->ops.dsat, sats[j - 1] + sub->ops.sat));
                     next_sats.push_back(sats[sats.size() - 1] + sub->ops.sat);
                     sats = std::move(next_sats);
                 }
                 assert(k <= sats.size());
-                return {stat, sats[k], sats[0]};
+                return {count, sats[k], sats[0]};
             }
         }
         assert(false);
@@ -717,32 +745,40 @@ private:
 
     internal::StackSize CalcStackSize() const {
         switch (nodetype) {
-            case NodeType::PK_K: return {1, 1};
-            case NodeType::PK_H: return {2, 2};
-            case NodeType::OLDER: return {0, {}};
-            case NodeType::AFTER: return {0, {}};
-            case NodeType::SHA256: return {1, {}};
-            case NodeType::RIPEMD160: return {1, {}};
-            case NodeType::HASH256: return {1, {}};
-            case NodeType::HASH160: return {1, {}};
-            case NodeType::ANDOR: return {Choose(subs[0]->ss.sat + subs[1]->ss.sat, subs[0]->ss.dsat + subs[2]->ss.sat), subs[0]->ss.dsat + subs[2]->ss.dsat};
-            case NodeType::AND_V: return {subs[0]->ss.sat + subs[1]->ss.sat, {}};
-            case NodeType::AND_B: return {subs[0]->ss.sat + subs[1]->ss.sat, subs[0]->ss.dsat + subs[1]->ss.dsat};
-            case NodeType::OR_B: return {Choose(subs[0]->ss.dsat + subs[1]->ss.sat, subs[0]->ss.sat + subs[1]->ss.dsat), subs[0]->ss.dsat + subs[1]->ss.dsat};
-            case NodeType::OR_C: return {Choose(subs[0]->ss.sat, subs[0]->ss.dsat + subs[1]->ss.sat), {}};
-            case NodeType::OR_D: return {Choose(subs[0]->ss.sat, subs[0]->ss.dsat + subs[1]->ss.sat), subs[0]->ss.dsat + subs[1]->ss.dsat};
-            case NodeType::OR_I: return {Choose(subs[0]->ss.sat + 1, subs[1]->ss.sat + 1), Choose(subs[0]->ss.dsat + 1, subs[1]->ss.dsat + 1)};
-            case NodeType::MULTI: return {(uint32_t)keys.size() + 1, (uint32_t)keys.size() + 1};
-            case NodeType::WRAP_A: return subs[0]->ss;
-            case NodeType::WRAP_S: return subs[0]->ss;
-            case NodeType::WRAP_C: return subs[0]->ss;
-            case NodeType::WRAP_D: return {1 + subs[0]->ss.sat, 1};
-            case NodeType::WRAP_V: return {subs[0]->ss.sat, {}};
-            case NodeType::WRAP_J: return {subs[0]->ss.sat, 1};
-            case NodeType::WRAP_N: return subs[0]->ss;
-            case NodeType::JUST_1: return {0, {}};
-            case NodeType::JUST_0: return {{}, 0};
-            case NodeType::THRESH: {
+            case Fragment::JUST_0: return {{}, 0};
+            case Fragment::JUST_1:
+            case Fragment::OLDER:
+            case Fragment::AFTER: return {0, {}};
+            case Fragment::PK_K: return {1, 1};
+            case Fragment::PK_H: return {2, 2};
+            case Fragment::SHA256:
+            case Fragment::RIPEMD160:
+            case Fragment::HASH256:
+            case Fragment::HASH160: return {1, {}};
+            case Fragment::ANDOR: {
+                const internal::MaxInt<uint32_t> sat{Choose(subs[0]->ss.sat + subs[1]->ss.sat, subs[0]->ss.dsat + subs[2]->ss.sat)};
+                const internal::MaxInt<uint32_t> dsat{subs[0]->ss.dsat + subs[2]->ss.dsat};
+                return {sat, dsat};
+            }
+            case Fragment::AND_V: return {subs[0]->ss.sat + subs[1]->ss.sat, {}};
+            case Fragment::AND_B: return {subs[0]->ss.sat + subs[1]->ss.sat, subs[0]->ss.dsat + subs[1]->ss.dsat};
+            case Fragment::OR_B: {
+                const internal::MaxInt<uint32_t> sat{Choose(subs[0]->ss.dsat + subs[1]->ss.sat, subs[0]->ss.sat + subs[1]->ss.dsat)};
+                const internal::MaxInt<uint32_t> dsat{subs[0]->ss.dsat + subs[1]->ss.dsat};
+                return {sat, dsat};
+            }
+            case Fragment::OR_C: return {Choose(subs[0]->ss.sat, subs[0]->ss.dsat + subs[1]->ss.sat), {}};
+            case Fragment::OR_D: return {Choose(subs[0]->ss.sat, subs[0]->ss.dsat + subs[1]->ss.sat), subs[0]->ss.dsat + subs[1]->ss.dsat};
+            case Fragment::OR_I: return {Choose(subs[0]->ss.sat + 1, subs[1]->ss.sat + 1), Choose(subs[0]->ss.dsat + 1, subs[1]->ss.dsat + 1)};
+            case Fragment::MULTI: return {(uint32_t)keys.size() + 1, (uint32_t)keys.size() + 1};
+            case Fragment::WRAP_A:
+            case Fragment::WRAP_N:
+            case Fragment::WRAP_S:
+            case Fragment::WRAP_C: return subs[0]->ss;
+            case Fragment::WRAP_D: return {1 + subs[0]->ss.sat, 1};
+            case Fragment::WRAP_V: return {subs[0]->ss.sat, {}};
+            case Fragment::WRAP_J: return {subs[0]->ss.sat, 1};
+            case Fragment::THRESH: {
                 auto sats = Vector(internal::MaxInt<uint32_t>(0));
                 for (const auto& sub : subs) {
                     auto next_sats = Vector(sats[0] + sub->ss.dsat);
@@ -765,17 +801,17 @@ private:
 
         auto helper = [&ctx, nonmal](const Node& node, Span<InputResult> subres) -> InputResult {
             switch (node.nodetype) {
-                case NodeType::PK_K: {
+                case Fragment::PK_K: {
                     std::vector<unsigned char> sig;
                     Availability avail = ctx.Sign(node.keys[0], sig);
                     return InputResult(ZERO, InputStack(std::move(sig)).WithSig().Available(avail));
                 }
-                case NodeType::PK_H: {
+                case Fragment::PK_H: {
                     std::vector<unsigned char> key = ctx.ToPKBytes(node.keys[0]), sig;
                     Availability avail = ctx.Sign(node.keys[0], sig);
                     return InputResult(ZERO + InputStack(key), (InputStack(std::move(sig)).WithSig() + InputStack(key)).Available(avail));
                 }
-                case NodeType::MULTI: {
+                case Fragment::MULTI: {
                     std::vector<InputStack> sats = Vector(ZERO);
                     for (size_t i = 0; i < node.keys.size(); ++i) {
                         std::vector<unsigned char> sig;
@@ -792,7 +828,7 @@ private:
                     assert(node.k <= sats.size());
                     return InputResult(std::move(nsat), std::move(sats[node.k]));
                 }
-                case NodeType::THRESH: {
+                case Fragment::THRESH: {
                     std::vector<InputStack> sats = Vector(EMPTY);
                     for (size_t i = 0; i < subres.size(); ++i) {
                         auto& res = subres[subres.size() - i - 1];
@@ -809,71 +845,71 @@ private:
                     assert(node.k <= sats.size());
                     return InputResult(std::move(nsat), std::move(sats[node.k]));
                 }
-                case NodeType::OLDER: {
+                case Fragment::OLDER: {
                     return InputResult(INVALID, ctx.CheckOlder(node.k) ? EMPTY : INVALID);
                 }
-                case NodeType::AFTER: {
+                case Fragment::AFTER: {
                     return InputResult(INVALID, ctx.CheckAfter(node.k) ? EMPTY : INVALID);
                 }
-                case NodeType::SHA256: {
+                case Fragment::SHA256: {
                     std::vector<unsigned char> preimage;
                     Availability avail = ctx.SatSHA256(node.data, preimage);
                     return InputResult(ZERO32, InputStack(std::move(preimage)).Available(avail));
                 }
-                case NodeType::RIPEMD160: {
+                case Fragment::RIPEMD160: {
                     std::vector<unsigned char> preimage;
                     Availability avail = ctx.SatRIPEMD160(node.data, preimage);
                     return InputResult(ZERO32, InputStack(std::move(preimage)).Available(avail));
                 }
-                case NodeType::HASH256: {
+                case Fragment::HASH256: {
                     std::vector<unsigned char> preimage;
                     Availability avail = ctx.SatHASH256(node.data, preimage);
                     return InputResult(ZERO32, InputStack(std::move(preimage)).Available(avail));
                 }
-                case NodeType::HASH160: {
+                case Fragment::HASH160: {
                     std::vector<unsigned char> preimage;
                     Availability avail = ctx.SatHASH160(node.data, preimage);
                     return InputResult(ZERO32, InputStack(std::move(preimage)).Available(avail));
                 }
-                case NodeType::AND_V: {
+                case Fragment::AND_V: {
                     auto& x = subres[0], &y = subres[1];
                     return InputResult((y.nsat + x.sat).NonCanon(), y.sat + x.sat);
                 }
-                case NodeType::AND_B: {
+                case Fragment::AND_B: {
                     auto& x = subres[0], &y = subres[1];
                     return InputResult(Choose(Choose(y.nsat + x.nsat, (y.sat + x.nsat).NonCanon(), nonmal), (y.nsat + x.sat).NonCanon(), nonmal), y.sat + x.sat);
                 }
-                case NodeType::OR_B: {
+                case Fragment::OR_B: {
                     auto& x = subres[0], &z = subres[1];
                     return InputResult(z.nsat + x.nsat, Choose(Choose(z.nsat + x.sat, z.sat + x.nsat, nonmal), (z.sat + x.sat).NonCanon(), nonmal));
                 }
-                case NodeType::OR_C: {
+                case Fragment::OR_C: {
                     auto& x = subres[0], &z = subres[1];
                     return InputResult(INVALID, Choose(std::move(x.sat), z.sat + x.nsat, nonmal));
                 }
-                case NodeType::OR_D: {
+                case Fragment::OR_D: {
                     auto& x = subres[0], &z = subres[1];
                     auto nsat = z.nsat + x.nsat, sat_l = x.sat, sat_r = z.sat + x.nsat;
                     return InputResult(z.nsat + x.nsat, Choose(std::move(x.sat), z.sat + x.nsat, nonmal));
                 }
-                case NodeType::OR_I: {
+                case Fragment::OR_I: {
                     auto& x = subres[0], &z = subres[1];
                     return InputResult(Choose(x.nsat + ONE, z.nsat + ZERO, nonmal), Choose(x.sat + ONE, z.sat + ZERO, nonmal));
                 }
-                case NodeType::ANDOR: {
+                case Fragment::ANDOR: {
                     auto& x = subres[0], &y = subres[1], &z = subres[2];
                     return InputResult(Choose((y.nsat + x.sat).NonCanon(), z.nsat + x.nsat, nonmal), Choose(y.sat + x.sat, z.sat + x.nsat, nonmal));
                 }
-                case NodeType::WRAP_A:
-                case NodeType::WRAP_S:
-                case NodeType::WRAP_C:
-                case NodeType::WRAP_N:
+                case Fragment::WRAP_A:
+                case Fragment::WRAP_S:
+                case Fragment::WRAP_C:
+                case Fragment::WRAP_N:
                     return std::move(subres[0]);
-                case NodeType::WRAP_D: {
+                case Fragment::WRAP_D: {
                     auto &x = subres[0];
                     return InputResult(ZERO, x.sat + ONE);
                 }
-                case NodeType::WRAP_J: {
+                case Fragment::WRAP_J: {
                     auto &x = subres[0];
                     // If a dissatisfaction with a nonzero top stack element exists, an alternative dissatisfaction exists.
                     // As the dissatisfaction logic currently doesn't keep track of this nonzeroness property, and thus even
@@ -882,12 +918,12 @@ private:
                     // dissatisfiable, this alternative dissatisfaction exists and leads to malleability.
                     return InputResult(InputStack(ZERO).Malleable(x.nsat.available != Availability::NO && !x.nsat.has_sig), std::move(x.sat));
                 }
-                case NodeType::WRAP_V: {
+                case Fragment::WRAP_V: {
                     auto &x = subres[0];
                     return InputResult(INVALID, std::move(x.sat));
                 }
-                case NodeType::JUST_0: return InputResult(EMPTY, INVALID);
-                case NodeType::JUST_1: return InputResult(INVALID, EMPTY);
+                case Fragment::JUST_0: return InputResult(EMPTY, INVALID);
+                case Fragment::JUST_1: return InputResult(INVALID, EMPTY);
             }
             assert(false);
             return InputResult(INVALID, INVALID);
@@ -923,12 +959,13 @@ public:
     size_t ScriptSize() const { return scriptlen; }
 
     //! Return the maximum number of ops needed to satisfy this script non-malleably.
-    uint32_t GetOps() const { return ops.stat + ops.sat.value; }
+    uint32_t GetOps() const { return ops.count + ops.sat.value; }
 
     //! Check the ops limit of this script against the consensus limit.
     bool CheckOpsLimit() const { return GetOps() <= MAX_OPS_PER_SCRIPT; }
 
-    //! Return the maximum number of stack elements needed to satisfy this script non-malleably.
+    /** Return the maximum number of stack elements needed to satisfy this script non-malleably, including
+     * the script push. */
     uint32_t GetStackSize() const { return ss.sat.value + 1; }
 
     //! Check the maximum stack size for this script against the policy limit.
@@ -936,6 +973,22 @@ public:
 
     //! Return the expression type.
     Type GetType() const { return typ; }
+
+    //! Find the deepest insane sub. Null if there is none.
+    NodeRef<Key> FindInsaneSub() const {
+        auto downfn = [](NodeRef<Key> curr_insane, const Node& node, size_t i) {
+            if (!node.subs[i]->IsSane()) return node.subs[i];
+            return curr_insane;
+        };
+
+        auto upfn = [](NodeRef<Key> curr_insane, const Node& node, Span<NodeRef<Key>> subs) {
+            for (const auto& sub: subs) if (sub) return sub;
+            return curr_insane;
+        };
+
+        NodeRef<Key> null;
+        return TreeEvalMaybe<NodeRef<Key>>(null, downfn, upfn).value_or(null);
+    }
 
     //! Check whether this node is valid at all.
     bool IsValid() const { return !(GetType() == ""_mst) && ScriptSize() <= MAX_STANDARD_P2WSH_SCRIPT_SIZE; }
@@ -949,12 +1002,16 @@ public:
     //! Check whether this script always needs a signature.
     bool NeedsSignature() const { return GetType() << "s"_mst; }
 
+    //! Check whether there is no satisfaction path that contains both timelocks and heightlocks
+    bool CheckTimeLocksMix() const { return GetType() << "k"_mst; }
+
     //! Do all sanity checks.
-    bool IsSane() const { return GetType() << "mk"_mst && CheckOpsLimit() && CheckStackSize() && IsValid(); }
+    bool IsSane() const { return IsValid() && IsNonMalleable() && CheckTimeLocksMix() && CheckOpsLimit() && CheckStackSize(); }
 
     //! Check whether this node is safe as a script on its own.
-    bool IsSaneTopLevel() const { return GetType() << "Bs"_mst && IsSane() && IsValidTopLevel(); }
+    bool IsSaneTopLevel() const { return IsValidTopLevel() && IsSane() && NeedsSignature(); }
 
+    //! Produce a witness for this script, if possible and given the information available in the context.
     template<typename Ctx>
     Availability Satisfy(const Ctx& ctx, std::vector<std::vector<unsigned char>>& stack, bool nonmalleable = true) const {
         auto ret = ProduceInput(ctx, nonmalleable);
@@ -980,12 +1037,12 @@ public:
     }
 
     // Constructors with various argument combinations.
-    Node(NodeType nt, std::vector<NodeRef<Key>> sub, std::vector<unsigned char> arg, uint32_t val = 0) : nodetype(nt), k(val), data(std::move(arg)), subs(std::move(sub)), ops(CalcOps()), ss(CalcStackSize()), typ(CalcType()), scriptlen(CalcScriptLen()) {}
-    Node(NodeType nt, std::vector<unsigned char> arg, uint32_t val = 0) : nodetype(nt), k(val), data(std::move(arg)), ops(CalcOps()), ss(CalcStackSize()), typ(CalcType()), scriptlen(CalcScriptLen()) {}
-    Node(NodeType nt, std::vector<NodeRef<Key>> sub, std::vector<Key> key, uint32_t val = 0) : nodetype(nt), k(val), keys(std::move(key)), subs(std::move(sub)), ops(CalcOps()), ss(CalcStackSize()), typ(CalcType()), scriptlen(CalcScriptLen()) {}
-    Node(NodeType nt, std::vector<Key> key, uint32_t val = 0) : nodetype(nt), k(val), keys(std::move(key)), ops(CalcOps()), ss(CalcStackSize()), typ(CalcType()), scriptlen(CalcScriptLen()) {}
-    Node(NodeType nt, std::vector<NodeRef<Key>> sub, uint32_t val = 0) : nodetype(nt), k(val), subs(std::move(sub)), ops(CalcOps()), ss(CalcStackSize()), typ(CalcType()), scriptlen(CalcScriptLen()) {}
-    Node(NodeType nt, uint32_t val = 0) : nodetype(nt), k(val), ops(CalcOps()), ss(CalcStackSize()), typ(CalcType()), scriptlen(CalcScriptLen()) {}
+    Node(Fragment nt, std::vector<NodeRef<Key>> sub, std::vector<unsigned char> arg, uint32_t val = 0) : nodetype(nt), k(val), data(std::move(arg)), subs(std::move(sub)), ops(CalcOps()), ss(CalcStackSize()), typ(CalcType()), scriptlen(CalcScriptLen()) {}
+    Node(Fragment nt, std::vector<unsigned char> arg, uint32_t val = 0) : nodetype(nt), k(val), data(std::move(arg)), ops(CalcOps()), ss(CalcStackSize()), typ(CalcType()), scriptlen(CalcScriptLen()) {}
+    Node(Fragment nt, std::vector<NodeRef<Key>> sub, std::vector<Key> key, uint32_t val = 0) : nodetype(nt), k(val), keys(std::move(key)), subs(std::move(sub)), ops(CalcOps()), ss(CalcStackSize()), typ(CalcType()), scriptlen(CalcScriptLen()) {}
+    Node(Fragment nt, std::vector<Key> key, uint32_t val = 0) : nodetype(nt), k(val), keys(std::move(key)), ops(CalcOps()), ss(CalcStackSize()), typ(CalcType()), scriptlen(CalcScriptLen()) {}
+    Node(Fragment nt, std::vector<NodeRef<Key>> sub, uint32_t val = 0) : nodetype(nt), k(val), subs(std::move(sub)), ops(CalcOps()), ss(CalcStackSize()), typ(CalcType()), scriptlen(CalcScriptLen()) {}
+    Node(Fragment nt, uint32_t val = 0) : nodetype(nt), k(val), ops(CalcOps()), ss(CalcStackSize()), typ(CalcType()), scriptlen(CalcScriptLen()) {}
 };
 
 namespace internal {
@@ -1044,12 +1101,36 @@ enum class ParseContext {
     CLOSE_BRACKET,
 };
 
-
 int FindNextChar(Span<const char> in, const char m);
 
-/** BuildBack pops the last two elements off `constructed` and wraps them in the specified NodeType */
+/** Parse a key string ending at the end of the fragment's text representation. */
+template<typename Key, typename Ctx>
+std::optional<std::pair<Key, int>> ParseKey(Span<const char> in, const Ctx& ctx)
+{
+    Key key;
+    int key_size = FindNextChar(in, ')');
+    if (key_size < 1) return {};
+    if (!ctx.FromString(in.begin(), in.begin() + key_size, key)) return {};
+    return {{key, key_size}};
+}
+
+/** Parse a hex string ending at the end of the fragment's text representation. */
+template<typename Ctx>
+std::optional<std::pair<std::vector<unsigned char>, int>> ParseHexStr(Span<const char> in, const size_t expected_size,
+                                                                      const Ctx& ctx)
+{
+    int hash_size = FindNextChar(in, ')');
+    if (hash_size < 1) return {};
+    std::string val = std::string(in.begin(), in.begin() + hash_size);
+    if (!IsHex(val)) return {};
+    auto hash = ParseHex(val);
+    if (hash.size() != expected_size) return {};
+    return {{hash, hash_size}};
+}
+
+/** BuildBack pops the last two elements off `constructed` and wraps them in the specified Fragment */
 template<typename Key>
-void BuildBack(NodeType nt, std::vector<NodeRef<Key>>& constructed, const bool reverse = false)
+void BuildBack(Fragment nt, std::vector<NodeRef<Key>>& constructed, const bool reverse = false)
 {
     NodeRef<Key> child = std::move(constructed.back());
     constructed.pop_back();
@@ -1060,7 +1141,11 @@ void BuildBack(NodeType nt, std::vector<NodeRef<Key>>& constructed, const bool r
     }
 }
 
-//! Parse a miniscript from its textual descriptor form.
+/**
+ * Parse a miniscript from its textual descriptor form.
+ * This does not check whether the script is valid, let alone sane. The caller is expected to use
+ * the `IsValidTopLevel()` and `IsSaneTopLevel()` to check for these properties on the node.
+ */
 template<typename Key, typename Ctx>
 inline NodeRef<Key> Parse(Span<const char> in, const Ctx& ctx)
 {
@@ -1109,7 +1194,7 @@ inline NodeRef<Key> Parse(Span<const char> in, const Ctx& ctx)
                     to_parse.emplace_back(ParseContext::WRAP_T, -1, -1);
                 } else if (in[j] == 'l') {
                     // The l: wrapper is equivalent to or_i(0,X)
-                    constructed.push_back(MakeNodeRef<Key>(NodeType::JUST_0));
+                    constructed.push_back(MakeNodeRef<Key>(Fragment::JUST_0));
                     to_parse.emplace_back(ParseContext::OR_I, -1, -1);
                 } else {
                     return {};
@@ -1121,72 +1206,56 @@ inline NodeRef<Key> Parse(Span<const char> in, const Ctx& ctx)
         }
         case ParseContext::EXPR: {
             if (Const("0", in)) {
-                constructed.push_back(MakeNodeRef<Key>(NodeType::JUST_0));
+                constructed.push_back(MakeNodeRef<Key>(Fragment::JUST_0));
             } else if (Const("1", in)) {
-                constructed.push_back(MakeNodeRef<Key>(NodeType::JUST_1));
+                constructed.push_back(MakeNodeRef<Key>(Fragment::JUST_1));
             } else if (Const("pk(", in)) {
-                Key key;
-                int key_size = FindNextChar(in, ')');
-                if (key_size < 1) return {};
-                if (!ctx.FromString(in.begin(), in.begin() + key_size, key)) return {};
-                constructed.push_back(MakeNodeRef<Key>(NodeType::WRAP_C, Vector(MakeNodeRef<Key>(NodeType::PK_K, Vector(std::move(key))))));
+                auto res = ParseKey<Key, Ctx>(in, ctx);
+                if (!res) return {};
+                auto [key, key_size] = *res;
+                constructed.push_back(MakeNodeRef<Key>(Fragment::WRAP_C, Vector(MakeNodeRef<Key>(Fragment::PK_K, Vector(std::move(key))))));
                 in = in.subspan(key_size + 1);
             } else if (Const("pkh(", in)) {
-                Key key;
-                int key_size = FindNextChar(in, ')');
-                if (key_size < 1) return {};
-                if (!ctx.FromString(in.begin(), in.begin() + key_size, key)) return {};
-                constructed.push_back(MakeNodeRef<Key>(NodeType::WRAP_C, Vector(MakeNodeRef<Key>(NodeType::PK_H, Vector(std::move(key))))));
+                auto res = ParseKey<Key>(in, ctx);
+                if (!res) return {};
+                auto [key, key_size] = *res;
+                constructed.push_back(MakeNodeRef<Key>(Fragment::WRAP_C, Vector(MakeNodeRef<Key>(Fragment::PK_H, Vector(std::move(key))))));
                 in = in.subspan(key_size + 1);
             } else if (Const("pk_k(", in)) {
-                Key key;
-                int key_size = FindNextChar(in, ')');
-                if (key_size < 1) return {};
-                if (!ctx.FromString(in.begin(), in.begin() + key_size, key)) return {};
-                constructed.push_back(MakeNodeRef<Key>(NodeType::PK_K, Vector(std::move(key))));
+                auto res = ParseKey<Key>(in, ctx);
+                if (!res) return {};
+                auto [key, key_size] = *res;
+                constructed.push_back(MakeNodeRef<Key>(Fragment::PK_K, Vector(std::move(key))));
                 in = in.subspan(key_size + 1);
             } else if (Const("pk_h(", in)) {
-                Key key;
-                int key_size = FindNextChar(in, ')');
-                if (key_size < 1) return {};
-                if (!ctx.FromString(in.begin(), in.begin() + key_size, key)) return {};
-                constructed.push_back(MakeNodeRef<Key>(NodeType::PK_H, Vector(std::move(key))));
+                auto res = ParseKey<Key>(in, ctx);
+                if (!res) return {};
+                auto [key, key_size] = *res;
+                constructed.push_back(MakeNodeRef<Key>(Fragment::PK_H, Vector(std::move(key))));
                 in = in.subspan(key_size + 1);
             } else if (Const("sha256(", in)) {
-                int hash_size = FindNextChar(in, ')');
-                if (hash_size < 1) return {};
-                std::string val = std::string(in.begin(), in.begin() + hash_size);
-                if (!IsHex(val)) return {};
-                auto hash = ParseHex(val);
-                if (hash.size() != 32) return {};
-                constructed.push_back(MakeNodeRef<Key>(NodeType::SHA256, std::move(hash)));
+                auto res = ParseHexStr(in, 32, ctx);
+                if (!res) return {};
+                auto [hash, hash_size] = *res;
+                constructed.push_back(MakeNodeRef<Key>(Fragment::SHA256, std::move(hash)));
                 in = in.subspan(hash_size + 1);
             } else if (Const("ripemd160(", in)) {
-                int hash_size = FindNextChar(in, ')');
-                if (hash_size < 1) return {};
-                std::string val = std::string(in.begin(), in.begin() + hash_size);
-                if (!IsHex(val)) return {};
-                auto hash = ParseHex(val);
-                if (hash.size() != 20) return {};
-                constructed.push_back(MakeNodeRef<Key>(NodeType::RIPEMD160, std::move(hash)));
+                auto res = ParseHexStr(in, 20, ctx);
+                if (!res) return {};
+                auto [hash, hash_size] = *res;
+                constructed.push_back(MakeNodeRef<Key>(Fragment::RIPEMD160, std::move(hash)));
                 in = in.subspan(hash_size + 1);
             } else if (Const("hash256(", in)) {
-                int hash_size = FindNextChar(in, ')');
-                if (hash_size < 1) return {};
-                std::string val = std::string(in.begin(), in.begin() + hash_size);
-                if (!IsHex(val)) return {};
-                auto hash = ParseHex(val);
-                if (hash.size() != 32) return {};
-                constructed.push_back(MakeNodeRef<Key>(NodeType::HASH256, std::move(hash)));
+                auto res = ParseHexStr(in, 32, ctx);
+                if (!res) return {};
+                auto [hash, hash_size] = *res;
+                constructed.push_back(MakeNodeRef<Key>(Fragment::HASH256, std::move(hash)));
                 in = in.subspan(hash_size + 1);
             } else if (Const("hash160(", in)) {
-                int hash_size = FindNextChar(in, ')');
-                if (hash_size < 1) return {};
-                std::string val = std::string(in.begin(), in.begin() + hash_size);
-                if (!IsHex(val)) return {};
-                auto hash = ParseHex(val);
-                if (hash.size() != 20) return {};
-                constructed.push_back(MakeNodeRef<Key>(NodeType::HASH160, std::move(hash)));
+                auto res = ParseHexStr(in, 20, ctx);
+                if (!res) return {};
+                auto [hash, hash_size] = *res;
+                constructed.push_back(MakeNodeRef<Key>(Fragment::HASH160, std::move(hash)));
                 in = in.subspan(hash_size + 1);
             } else if (Const("after(", in)) {
                 int arg_size = FindNextChar(in, ')');
@@ -1194,7 +1263,7 @@ inline NodeRef<Key> Parse(Span<const char> in, const Ctx& ctx)
                 int64_t num;
                 if (!ParseInt64(std::string(in.begin(), in.begin() + arg_size), &num)) return {};
                 if (num < 1 || num >= 0x80000000L) return {};
-                constructed.push_back(MakeNodeRef<Key>(NodeType::AFTER, num));
+                constructed.push_back(MakeNodeRef<Key>(Fragment::AFTER, num));
                 in = in.subspan(arg_size + 1);
             } else if (Const("older(", in)) {
                 int arg_size = FindNextChar(in, ')');
@@ -1202,7 +1271,7 @@ inline NodeRef<Key> Parse(Span<const char> in, const Ctx& ctx)
                 int64_t num;
                 if (!ParseInt64(std::string(in.begin(), in.begin() + arg_size), &num)) return {};
                 if (num < 1 || num >= 0x80000000L) return {};
-                constructed.push_back(MakeNodeRef<Key>(NodeType::OLDER, num));
+                constructed.push_back(MakeNodeRef<Key>(Fragment::OLDER, num));
                 in = in.subspan(arg_size + 1);
             } else if (Const("multi(", in)) {
                 // Get threshold
@@ -1223,7 +1292,7 @@ inline NodeRef<Key> Parse(Span<const char> in, const Ctx& ctx)
                 }
                 if (keys.size() < 1 || keys.size() > 20) return {};
                 if (k < 1 || k > (int64_t)keys.size()) return {};
-                constructed.push_back(MakeNodeRef<Key>(NodeType::MULTI, std::move(keys), k));
+                constructed.push_back(MakeNodeRef<Key>(Fragment::MULTI, std::move(keys), k));
             } else if (Const("thresh(", in)) {
                 int next_comma = FindNextChar(in, ',');
                 if (next_comma < 1) return {};
@@ -1267,69 +1336,69 @@ inline NodeRef<Key> Parse(Span<const char> in, const Ctx& ctx)
             break;
         }
         case ParseContext::ALT: {
-            constructed.back() = MakeNodeRef<Key>(NodeType::WRAP_A, Vector(std::move(constructed.back())));
+            constructed.back() = MakeNodeRef<Key>(Fragment::WRAP_A, Vector(std::move(constructed.back())));
             break;
         }
         case ParseContext::SWAP: {
-            constructed.back() = MakeNodeRef<Key>(NodeType::WRAP_S, Vector(std::move(constructed.back())));
+            constructed.back() = MakeNodeRef<Key>(Fragment::WRAP_S, Vector(std::move(constructed.back())));
             break;
         }
         case ParseContext::CHECK: {
-            constructed.back() = MakeNodeRef<Key>(NodeType::WRAP_C, Vector(std::move(constructed.back())));
+            constructed.back() = MakeNodeRef<Key>(Fragment::WRAP_C, Vector(std::move(constructed.back())));
             break;
         }
         case ParseContext::DUP_IF: {
-            constructed.back() = MakeNodeRef<Key>(NodeType::WRAP_D, Vector(std::move(constructed.back())));
+            constructed.back() = MakeNodeRef<Key>(Fragment::WRAP_D, Vector(std::move(constructed.back())));
             break;
         }
         case ParseContext::NON_ZERO: {
-            constructed.back() = MakeNodeRef<Key>(NodeType::WRAP_J, Vector(std::move(constructed.back())));
+            constructed.back() = MakeNodeRef<Key>(Fragment::WRAP_J, Vector(std::move(constructed.back())));
             break;
         }
         case ParseContext::ZERO_NOTEQUAL: {
-            constructed.back() = MakeNodeRef<Key>(NodeType::WRAP_N, Vector(std::move(constructed.back())));
+            constructed.back() = MakeNodeRef<Key>(Fragment::WRAP_N, Vector(std::move(constructed.back())));
             break;
         }
         case ParseContext::VERIFY: {
-            constructed.back() = MakeNodeRef<Key>(NodeType::WRAP_V, Vector(std::move(constructed.back())));
+            constructed.back() = MakeNodeRef<Key>(Fragment::WRAP_V, Vector(std::move(constructed.back())));
             break;
         }
         case ParseContext::WRAP_U: {
-            constructed.back() = MakeNodeRef<Key>(NodeType::OR_I, Vector(std::move(constructed.back()), MakeNodeRef<Key>(NodeType::JUST_0)));
+            constructed.back() = MakeNodeRef<Key>(Fragment::OR_I, Vector(std::move(constructed.back()), MakeNodeRef<Key>(Fragment::JUST_0)));
             break;
         }
         case ParseContext::WRAP_T: {
-            constructed.back() = MakeNodeRef<Key>(NodeType::AND_V, Vector(std::move(constructed.back()), MakeNodeRef<Key>(NodeType::JUST_1)));
+            constructed.back() = MakeNodeRef<Key>(Fragment::AND_V, Vector(std::move(constructed.back()), MakeNodeRef<Key>(Fragment::JUST_1)));
             break;
         }
         case ParseContext::AND_B: {
-            BuildBack(NodeType::AND_B, constructed);
+            BuildBack(Fragment::AND_B, constructed);
             break;
         }
         case ParseContext::AND_N: {
             auto mid = std::move(constructed.back());
             constructed.pop_back();
-            constructed.back() = MakeNodeRef<Key>(NodeType::ANDOR, Vector(std::move(constructed.back()), std::move(mid), MakeNodeRef<Key>(NodeType::JUST_0)));
+            constructed.back() = MakeNodeRef<Key>(Fragment::ANDOR, Vector(std::move(constructed.back()), std::move(mid), MakeNodeRef<Key>(Fragment::JUST_0)));
             break;
         }
         case ParseContext::AND_V: {
-            BuildBack(NodeType::AND_V, constructed);
+            BuildBack(Fragment::AND_V, constructed);
             break;
         }
         case ParseContext::OR_B: {
-            BuildBack(NodeType::OR_B, constructed);
+            BuildBack(Fragment::OR_B, constructed);
             break;
         }
         case ParseContext::OR_C: {
-            BuildBack(NodeType::OR_C, constructed);
+            BuildBack(Fragment::OR_C, constructed);
             break;
         }
         case ParseContext::OR_D: {
-            BuildBack(NodeType::OR_D, constructed);
+            BuildBack(Fragment::OR_D, constructed);
             break;
         }
         case ParseContext::OR_I: {
-            BuildBack(NodeType::OR_I, constructed);
+            BuildBack(Fragment::OR_I, constructed);
             break;
         }
         case ParseContext::ANDOR: {
@@ -1337,7 +1406,7 @@ inline NodeRef<Key> Parse(Span<const char> in, const Ctx& ctx)
             constructed.pop_back();
             auto mid = std::move(constructed.back());
             constructed.pop_back();
-            constructed.back() = MakeNodeRef<Key>(NodeType::ANDOR, Vector(std::move(constructed.back()), std::move(mid), std::move(right)));
+            constructed.back() = MakeNodeRef<Key>(Fragment::ANDOR, Vector(std::move(constructed.back()), std::move(mid), std::move(right)));
             break;
         }
         case ParseContext::THRESH: {
@@ -1356,7 +1425,7 @@ inline NodeRef<Key> Parse(Span<const char> in, const Ctx& ctx)
                     constructed.pop_back();
                 }
                 std::reverse(subs.begin(), subs.end());
-                constructed.push_back(MakeNodeRef<Key>(NodeType::THRESH, std::move(subs), k));
+                constructed.push_back(MakeNodeRef<Key>(Fragment::THRESH, std::move(subs), k));
             } else {
                 return {};
             }
@@ -1378,9 +1447,7 @@ inline NodeRef<Key> Parse(Span<const char> in, const Ctx& ctx)
     // Sanity checks on the produced miniscript
     assert(constructed.size() == 1);
     if (in.size() > 0) return {};
-    const NodeRef<Key> tl_node = std::move(constructed.front());
-    if (!tl_node->IsValidTopLevel()) return {};
-    return tl_node;
+    return std::move(constructed.front());
 }
 
 /** Decode a script into opcode/push pairs.
@@ -1491,49 +1558,64 @@ inline NodeRef<Key> DecodeScript(I& in, I last, const Ctx& ctx)
             // Constants
             if (in[0].first == OP_1) {
                 ++in;
-                constructed.push_back(MakeNodeRef<Key>(NodeType::JUST_1));
-            } else if (in[0].first == OP_0) {
+                constructed.push_back(MakeNodeRef<Key>(Fragment::JUST_1));
+                break;
+            }
+            if (in[0].first == OP_0) {
                 ++in;
-                constructed.push_back(MakeNodeRef<Key>(NodeType::JUST_0));
+                constructed.push_back(MakeNodeRef<Key>(Fragment::JUST_0));
+                break;
             }
             // Public keys
-            else if (in[0].second.size() == 33) {
+            if (in[0].second.size() == 33) {
                 Key key;
                 if (!ctx.FromPKBytes(in[0].second.begin(), in[0].second.end(), key)) return {};
                 ++in;
-                constructed.push_back(MakeNodeRef<Key>(NodeType::PK_K, Vector(std::move(key))));
-            } else if (last - in >= 5 && in[0].first == OP_VERIFY && in[1].first == OP_EQUAL && in[3].first == OP_HASH160 && in[4].first == OP_DUP && in[2].second.size() == 20) {
+                constructed.push_back(MakeNodeRef<Key>(Fragment::PK_K, Vector(std::move(key))));
+                break;
+            }
+            if (last - in >= 5 && in[0].first == OP_VERIFY && in[1].first == OP_EQUAL && in[3].first == OP_HASH160 && in[4].first == OP_DUP && in[2].second.size() == 20) {
                 Key key;
                 if (!ctx.FromPKHBytes(in[2].second.begin(), in[2].second.end(), key)) return {};
                 in += 5;
-                constructed.push_back(MakeNodeRef<Key>(NodeType::PK_H, Vector(std::move(key))));
+                constructed.push_back(MakeNodeRef<Key>(Fragment::PK_H, Vector(std::move(key))));
+                break;
             }
             // Time locks
-            else if (last - in >= 2 && in[0].first == OP_CHECKSEQUENCEVERIFY && ParseScriptNumber(in[1], k)) {
+            if (last - in >= 2 && in[0].first == OP_CHECKSEQUENCEVERIFY && ParseScriptNumber(in[1], k)) {
                 in += 2;
                 if (k < 1 || k > 0x7FFFFFFFL) return {};
-                constructed.push_back(MakeNodeRef<Key>(NodeType::OLDER, k));
-            } else if (last - in >= 2 && in[0].first == OP_CHECKLOCKTIMEVERIFY && ParseScriptNumber(in[1], k)) {
+                constructed.push_back(MakeNodeRef<Key>(Fragment::OLDER, k));
+                break;
+            }
+            if (last - in >= 2 && in[0].first == OP_CHECKLOCKTIMEVERIFY && ParseScriptNumber(in[1], k)) {
                 in += 2;
                 if (k < 1 || k > 0x7FFFFFFFL) return {};
-                constructed.push_back(MakeNodeRef<Key>(NodeType::AFTER, k));
+                constructed.push_back(MakeNodeRef<Key>(Fragment::AFTER, k));
+                break;
             }
             // Hashes
-            else if (last - in >= 7 && in[0].first == OP_EQUAL && in[1].second.size() == 32 && in[2].first == OP_SHA256 && in[3].first == OP_VERIFY && in[4].first == OP_EQUAL && ParseScriptNumber(in[5], k) && k == 32 && in[6].first == OP_SIZE) {
-                constructed.push_back(MakeNodeRef<Key>(NodeType::SHA256, in[1].second));
-                in += 7;
-            } else if (last - in >= 7 && in[0].first == OP_EQUAL && in[1].second.size() == 20 && in[2].first == OP_RIPEMD160 && in[3].first == OP_VERIFY && in[4].first == OP_EQUAL && ParseScriptNumber(in[5], k) && k == 32 && in[6].first == OP_SIZE) {
-                constructed.push_back(MakeNodeRef<Key>(NodeType::RIPEMD160, in[1].second));
-                in += 7;
-            } else if (last - in >= 7 && in[0].first == OP_EQUAL && in[1].second.size() == 32 && in[2].first == OP_HASH256 && in[3].first == OP_VERIFY && in[4].first == OP_EQUAL && ParseScriptNumber(in[5], k) && k == 32 && in[6].first == OP_SIZE) {
-                constructed.push_back(MakeNodeRef<Key>(NodeType::HASH256, in[1].second));
-                in += 7;
-            } else if (last - in >= 7 && in[0].first == OP_EQUAL && in[1].second.size() == 20 && in[2].first == OP_HASH160 && in[3].first == OP_VERIFY && in[4].first == OP_EQUAL && ParseScriptNumber(in[5], k) && k == 32 && in[6].first == OP_SIZE) {
-                constructed.push_back(MakeNodeRef<Key>(NodeType::HASH160, in[1].second));
-                in += 7;
+            if (last - in >= 7 && in[0].first == OP_EQUAL && in[3].first == OP_VERIFY && in[4].first == OP_EQUAL && ParseScriptNumber(in[5], k) && k == 32 && in[6].first == OP_SIZE) {
+                if (in[2].first == OP_SHA256 && in[1].second.size() == 32) {
+                    constructed.push_back(MakeNodeRef<Key>(Fragment::SHA256, in[1].second));
+                    in += 7;
+                    break;
+                } else if (in[2].first == OP_RIPEMD160 && in[1].second.size() == 20) {
+                    constructed.push_back(MakeNodeRef<Key>(Fragment::RIPEMD160, in[1].second));
+                    in += 7;
+                    break;
+                } else if (in[2].first == OP_HASH256 && in[1].second.size() == 32) {
+                    constructed.push_back(MakeNodeRef<Key>(Fragment::HASH256, in[1].second));
+                    in += 7;
+                    break;
+                } else if (in[2].first == OP_HASH160 && in[1].second.size() == 20) {
+                    constructed.push_back(MakeNodeRef<Key>(Fragment::HASH160, in[1].second));
+                    in += 7;
+                    break;
+                }
             }
             // Multi
-            else if (last - in >= 3 && in[0].first == OP_CHECKMULTISIG) {
+            if (last - in >= 3 && in[0].first == OP_CHECKMULTISIG) {
                 std::vector<Key> keys;
                 if (!ParseScriptNumber(in[1], n)) return {};
                 if (last - in < 3 + n) return {};
@@ -1548,40 +1630,46 @@ inline NodeRef<Key> DecodeScript(I& in, I last, const Ctx& ctx)
                 if (k < 1 || k > n) return {};
                 in += 3 + n;
                 std::reverse(keys.begin(), keys.end());
-                constructed.push_back(MakeNodeRef<Key>(NodeType::MULTI, std::move(keys), k));
+                constructed.push_back(MakeNodeRef<Key>(Fragment::MULTI, std::move(keys), k));
+                break;
             }
             /** In the following wrappers, we only need to push SINGLE_BKV_EXPR rather
              * than BKV_EXPR, because and_v commutes with these wrappers. For example,
              * c:and_v(X,Y) produces the same script as and_v(X,c:Y). */
             // c: wrapper
-            else if (in[0].first == OP_CHECKSIG) {
+            if (in[0].first == OP_CHECKSIG) {
                 ++in;
                 to_parse.emplace_back(DecodeContext::CHECK, -1, -1);
                 to_parse.emplace_back(DecodeContext::SINGLE_BKV_EXPR, -1, -1);
+                break;
             }
             // v: wrapper
-            else if (in[0].first == OP_VERIFY) {
+            if (in[0].first == OP_VERIFY) {
                 ++in;
                 to_parse.emplace_back(DecodeContext::VERIFY, -1, -1);
                 to_parse.emplace_back(DecodeContext::SINGLE_BKV_EXPR, -1, -1);
+                break;
             }
             // n: wrapper
-            else if (in[0].first == OP_0NOTEQUAL) {
+            if (in[0].first == OP_0NOTEQUAL) {
                 ++in;
                 to_parse.emplace_back(DecodeContext::ZERO_NOTEQUAL, -1, -1);
                 to_parse.emplace_back(DecodeContext::SINGLE_BKV_EXPR, -1, -1);
+                break;
             }
             // Thresh
-            else if (last - in >= 3 && in[0].first == OP_EQUAL && ParseScriptNumber(in[1], k)) {
+            if (last - in >= 3 && in[0].first == OP_EQUAL && ParseScriptNumber(in[1], k)) {
                 if (k < 1) return {};
                 in += 2;
                 to_parse.emplace_back(DecodeContext::THRESH_W, 0, k);
+                break;
             }
             // OP_ENDIF can be WRAP_J, WRAP_D, ANDOR, OR_C, OR_D, or OR_I
-            else if (in[0].first == OP_ENDIF) {
+            if (in[0].first == OP_ENDIF) {
                 ++in;
                 to_parse.emplace_back(DecodeContext::ENDIF, -1, -1);
                 to_parse.emplace_back(DecodeContext::BKV_EXPR, -1, -1);
+                break;
             }
             /** In and_b and or_b nodes, we only look for SINGLE_BKV_EXPR, because
              * or_b(and_v(X,Y),Z) has script [X] [Y] [Z] OP_BOOLOR, the same as
@@ -1589,23 +1677,23 @@ inline NodeRef<Key> DecodeScript(I& in, I last, const Ctx& ctx)
              * miniscript, while the latter is valid. So we leave the and_v "outside"
              * while decoding. */
             // and_b
-            else if (in[0].first == OP_BOOLAND) {
+            if (in[0].first == OP_BOOLAND) {
                 ++in;
                 to_parse.emplace_back(DecodeContext::AND_B, -1, -1);
                 to_parse.emplace_back(DecodeContext::SINGLE_BKV_EXPR, -1, -1);
                 to_parse.emplace_back(DecodeContext::W_EXPR, -1, -1);
+                break;
             }
             // or_b
-            else if (in[0].first == OP_BOOLOR) {
+            if (in[0].first == OP_BOOLOR) {
                 ++in;
                 to_parse.emplace_back(DecodeContext::OR_B, -1, -1);
                 to_parse.emplace_back(DecodeContext::SINGLE_BKV_EXPR, -1, -1);
                 to_parse.emplace_back(DecodeContext::W_EXPR, -1, -1);
-            } else {
-                // Unrecognised expression
-                return {};
+                break;
             }
-            break;
+            // Unrecognised expression
+            return {};
         }
         case DecodeContext::BKV_EXPR: {
             to_parse.emplace_back(DecodeContext::MAYBE_AND_V, -1, -1);
@@ -1635,64 +1723,75 @@ inline NodeRef<Key> DecodeScript(I& in, I last, const Ctx& ctx)
             break;
         }
         case DecodeContext::SWAP: {
-            if (in >= last || in[0].first != OP_SWAP) return {};
+            if (in >= last || in[0].first != OP_SWAP || constructed.empty()) return {};
             ++in;
-            constructed.back() = MakeNodeRef<Key>(NodeType::WRAP_S, Vector(std::move(constructed.back())));
+            constructed.back() = MakeNodeRef<Key>(Fragment::WRAP_S, Vector(std::move(constructed.back())));
             break;
         }
         case DecodeContext::ALT: {
-            if (in >= last || in[0].first != OP_TOALTSTACK) return {};
+            if (in >= last || in[0].first != OP_TOALTSTACK || constructed.empty()) return {};
             ++in;
-            constructed.back() = MakeNodeRef<Key>(NodeType::WRAP_A, Vector(std::move(constructed.back())));
+            constructed.back() = MakeNodeRef<Key>(Fragment::WRAP_A, Vector(std::move(constructed.back())));
             break;
         }
         case DecodeContext::CHECK: {
-            constructed.back() = MakeNodeRef<Key>(NodeType::WRAP_C, Vector(std::move(constructed.back())));
+            if (constructed.empty()) return {};
+            constructed.back() = MakeNodeRef<Key>(Fragment::WRAP_C, Vector(std::move(constructed.back())));
             break;
         }
         case DecodeContext::DUP_IF: {
-            constructed.back() = MakeNodeRef<Key>(NodeType::WRAP_D, Vector(std::move(constructed.back())));
+            if (constructed.empty()) return {};
+            constructed.back() = MakeNodeRef<Key>(Fragment::WRAP_D, Vector(std::move(constructed.back())));
             break;
         }
         case DecodeContext::VERIFY: {
-            constructed.back() = MakeNodeRef<Key>(NodeType::WRAP_V, Vector(std::move(constructed.back())));
+            if (constructed.empty()) return {};
+            constructed.back() = MakeNodeRef<Key>(Fragment::WRAP_V, Vector(std::move(constructed.back())));
             break;
         }
         case DecodeContext::NON_ZERO: {
-            constructed.back() = MakeNodeRef<Key>(NodeType::WRAP_J, Vector(std::move(constructed.back())));
+            if (constructed.empty()) return {};
+            constructed.back() = MakeNodeRef<Key>(Fragment::WRAP_J, Vector(std::move(constructed.back())));
             break;
         }
         case DecodeContext::ZERO_NOTEQUAL: {
-            constructed.back() = MakeNodeRef<Key>(NodeType::WRAP_N, Vector(std::move(constructed.back())));
+            if (constructed.empty()) return {};
+            constructed.back() = MakeNodeRef<Key>(Fragment::WRAP_N, Vector(std::move(constructed.back())));
             break;
         }
         case DecodeContext::AND_V: {
-            BuildBack(NodeType::AND_V, constructed, /* reverse */ true);
+            if (constructed.size() < 2) return {};
+            BuildBack(Fragment::AND_V, constructed, /* reverse */ true);
             break;
         }
         case DecodeContext::AND_B: {
-            BuildBack(NodeType::AND_B, constructed, /* reverse */ true);
+            if (constructed.size() < 2) return {};
+            BuildBack(Fragment::AND_B, constructed, /* reverse */ true);
             break;
         }
         case DecodeContext::OR_B: {
-            BuildBack(NodeType::OR_B, constructed, /* reverse */ true);
+            if (constructed.size() < 2) return {};
+            BuildBack(Fragment::OR_B, constructed, /* reverse */ true);
             break;
         }
         case DecodeContext::OR_C: {
-            BuildBack(NodeType::OR_C, constructed, /* reverse */ true);
+            if (constructed.size() < 2) return {};
+            BuildBack(Fragment::OR_C, constructed, /* reverse */ true);
             break;
         }
         case DecodeContext::OR_D: {
-            BuildBack(NodeType::OR_D, constructed, /* reverse */ true);
+            if (constructed.size() < 2) return {};
+            BuildBack(Fragment::OR_D, constructed, /* reverse */ true);
             break;
         }
         case DecodeContext::ANDOR: {
+            if (constructed.size() < 3) return {};
             NodeRef<Key> left = std::move(constructed.back());
             constructed.pop_back();
             NodeRef<Key> right = std::move(constructed.back());
             constructed.pop_back();
             NodeRef<Key> mid = std::move(constructed.back());
-            constructed.back() = MakeNodeRef<Key>(NodeType::ANDOR, Vector(std::move(left), std::move(mid), std::move(right)));
+            constructed.back() = MakeNodeRef<Key>(Fragment::ANDOR, Vector(std::move(left), std::move(mid), std::move(right)));
             break;
         }
         case DecodeContext::THRESH_W: {
@@ -1709,14 +1808,14 @@ inline NodeRef<Key> DecodeScript(I& in, I last, const Ctx& ctx)
             break;
         }
         case DecodeContext::THRESH_E: {
-            if (k < 1 || k > n) return {};
+            if (k < 1 || k > n || constructed.size() < static_cast<size_t>(n)) return {};
             std::vector<NodeRef<Key>> subs;
             for (int i = 0; i < n; ++i) {
                 NodeRef<Key> sub = std::move(constructed.back());
                 constructed.pop_back();
                 subs.push_back(std::move(sub));
             }
-            constructed.push_back(MakeNodeRef<Key>(NodeType::THRESH, std::move(subs), k));
+            constructed.push_back(MakeNodeRef<Key>(Fragment::THRESH, std::move(subs), k));
             break;
         }
         case DecodeContext::ENDIF: {
@@ -1766,7 +1865,7 @@ inline NodeRef<Key> DecodeScript(I& in, I last, const Ctx& ctx)
             if (in >= last) return {};
             if (in[0].first == OP_IF) {
                 ++in;
-                BuildBack(NodeType::OR_I, constructed, /* reverse */ true);
+                BuildBack(Fragment::OR_I, constructed, /* reverse */ true);
             } else if (in[0].first == OP_NOTIF) {
                 ++in;
                 to_parse.emplace_back(DecodeContext::ANDOR, -1, -1);

--- a/bitcoin/script/miniscript.h
+++ b/bitcoin/script/miniscript.h
@@ -20,6 +20,7 @@
 #include <span.h>
 #include <util/spanparsing.h>
 #include <util/strencodings.h>
+#include <util/string.h>
 #include <util/vector.h>
 #include <primitives/transaction.h>
 
@@ -624,8 +625,8 @@ public:
                     if (!ctx.ToString(node.keys[0], key_str)) return {};
                     return std::move(ret) + "pk_h(" + std::move(key_str) + ")";
                 }
-                case NodeType::AFTER: return std::move(ret) + "after(" + std::to_string(node.k) + ")";
-                case NodeType::OLDER: return std::move(ret) + "older(" + std::to_string(node.k) + ")";
+                case NodeType::AFTER: return std::move(ret) + "after(" + ::ToString(node.k) + ")";
+                case NodeType::OLDER: return std::move(ret) + "older(" + ::ToString(node.k) + ")";
                 case NodeType::HASH256: return std::move(ret) + "hash256(" + HexStr(node.data) + ")";
                 case NodeType::HASH160: return std::move(ret) + "hash160(" + HexStr(node.data) + ")";
                 case NodeType::SHA256: return std::move(ret) + "sha256(" + HexStr(node.data) + ")";
@@ -643,7 +644,7 @@ public:
                     if (node.subs[2]->nodetype == NodeType::JUST_0) return std::move(ret) + "and_n(" + std::move(subs[0]) + "," + std::move(subs[1]) + ")";
                     return std::move(ret) + "andor(" + std::move(subs[0]) + "," + std::move(subs[1]) + "," + std::move(subs[2]) + ")";
                 case NodeType::MULTI: {
-                    auto str = std::move(ret) + "multi(" + std::to_string(node.k);
+                    auto str = std::move(ret) + "multi(" + ::ToString(node.k);
                     for (const auto& key : node.keys) {
                         std::string key_str;
                         if (!ctx.ToString(key, key_str)) return {};
@@ -652,7 +653,7 @@ public:
                     return std::move(str) + ")";
                 }
                 case NodeType::THRESH: {
-                    auto str = std::move(ret) + "thresh(" + std::to_string(node.k);
+                    auto str = std::move(ret) + "thresh(" + ::ToString(node.k);
                     for (auto& sub : subs) {
                         str += "," + std::move(sub);
                     }

--- a/bitcoin/test/fuzz/miniscript_random.cpp
+++ b/bitcoin/test/fuzz/miniscript_random.cpp
@@ -1,0 +1,414 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <core_io.h>
+#include <hash.h>
+#include <key.h>
+#include <script/miniscript.h>
+#include <script/script.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <util/strencodings.h>
+
+
+//! Some pre-computed data to simulate challenges.
+struct TestData {
+    typedef CPubKey Key;
+
+    // Precomputed public keys, and a dummy signature for each of them.
+    std::vector<Key> dummy_keys;
+    std::map<CKeyID, Key> dummy_keys_map;
+    std::map<Key, std::vector<unsigned char>> dummy_sigs;
+
+    // Precomputed hashes of each kind.
+    std::vector<std::vector<unsigned char>> sha256;
+    std::vector<std::vector<unsigned char>> ripemd160;
+    std::vector<std::vector<unsigned char>> hash256;
+    std::vector<std::vector<unsigned char>> hash160;
+    std::map<std::vector<unsigned char>, std::vector<unsigned char>> sha256_preimages;
+    std::map<std::vector<unsigned char>, std::vector<unsigned char>> ripemd160_preimages;
+    std::map<std::vector<unsigned char>, std::vector<unsigned char>> hash256_preimages;
+    std::map<std::vector<unsigned char>, std::vector<unsigned char>> hash160_preimages;
+
+    //! Set the precomputed data.
+    void Init() {
+        unsigned char keydata[32] = {1};
+        for (size_t i = 0; i < 256; i++) {
+            keydata[31] = i;
+            CKey privkey;
+            privkey.Set(keydata, keydata + 32, true);
+            const Key pubkey = privkey.GetPubKey();
+
+            dummy_keys.push_back(pubkey);
+            dummy_keys_map.insert({pubkey.GetID(), pubkey});
+            std::vector<unsigned char> sig;
+            privkey.Sign(uint256S(""), sig);
+            sig.push_back(1); // SIGHASH_ALL
+            dummy_sigs.insert({pubkey, sig});
+
+            std::vector<unsigned char> hash;
+            hash.resize(32);
+            CSHA256().Write(keydata, 32).Finalize(hash.data());
+            sha256.push_back(hash);
+            sha256_preimages[hash] = std::vector<unsigned char>(keydata, keydata + 32);
+            CHash256().Write(keydata).Finalize(hash);
+            hash256.push_back(hash);
+            hash256_preimages[hash] = std::vector<unsigned char>(keydata, keydata + 32);
+            hash.resize(20);
+            CRIPEMD160().Write(keydata, 32).Finalize(hash.data());
+            assert(hash.size() == 20);
+            ripemd160.push_back(hash);
+            ripemd160_preimages[hash] = std::vector<unsigned char>(keydata, keydata + 32);
+            CHash160().Write(keydata).Finalize(hash);
+            hash160.push_back(hash);
+            hash160_preimages[hash] = std::vector<unsigned char>(keydata, keydata + 32);
+        }
+    }
+};
+
+//! Context to parse a Miniscript node to and from Script or text representation.
+struct ParserContext {
+    typedef CPubKey Key;
+    TestData *test_data;
+
+    bool ToString(const Key& key, std::string& ret) const { ret = HexStr(key); return true; }
+
+    const std::vector<unsigned char> ToPKBytes(const Key& key) const { return {key.begin(), key.end()}; }
+
+    const std::vector<unsigned char> ToPKHBytes(const Key& key) const {
+        const auto h = Hash160(key);
+        return {h.begin(), h.end()};
+    }
+
+    template<typename I>
+    bool FromString(I first, I last, Key& key) const {
+        const auto bytes = ParseHex(std::string(first, last));
+        key.Set(bytes.begin(), bytes.end());
+        return key.IsValid();
+    }
+
+    template<typename I>
+    bool FromPKBytes(I first, I last, CPubKey& key) const {
+        key.Set(first, last);
+        return key.IsValid();
+    }
+
+    template<typename I>
+    bool FromPKHBytes(I first, I last, CPubKey& key) const {
+        assert(last - first == 20);
+        CKeyID keyid;
+        std::copy(first, last, keyid.begin());
+        const auto it = test_data->dummy_keys_map.find(keyid);
+        if (it == test_data->dummy_keys_map.end()) return false;
+        key = it->second;
+        return true;
+    }
+};
+
+//! Context to produce a satisfaction for a Miniscript node using the pre-computed data.
+struct SatisfierContext: ParserContext {
+    // Timelock challenges satisfaction. Make the value (deterministically) vary to explore different
+    // paths.
+    bool CheckAfter(uint32_t value) const { return value % 2; }
+    bool CheckOlder(uint32_t value) const { return value % 2; }
+
+    // Signature challenges fulfilled with a dummy signature, if it was one of our dummy keys.
+    miniscript::Availability Sign(const CPubKey& key, std::vector<unsigned char>& sig) const {
+        const auto it = test_data->dummy_sigs.find(key);
+        if (it == test_data->dummy_sigs.end()) return miniscript::Availability::NO;
+        sig = it->second;
+        return miniscript::Availability::YES;
+    }
+
+    //! Lookup generalization for all the hash satisfactions below
+    miniscript::Availability LookupHash(const std::vector<unsigned char>& hash, std::vector<unsigned char>& preimage,
+                                        const std::map<std::vector<unsigned char>, std::vector<unsigned char>>& map) const
+    {
+        const auto it = map.find(hash);
+        if (it == map.end()) return miniscript::Availability::NO;
+        preimage = it->second;
+        return miniscript::Availability::YES;
+    }
+    miniscript::Availability SatSHA256(const std::vector<unsigned char>& hash, std::vector<unsigned char>& preimage) const {
+        return LookupHash(hash, preimage, test_data->sha256_preimages);
+    }
+    miniscript::Availability SatRIPEMD160(const std::vector<unsigned char>& hash, std::vector<unsigned char>& preimage) const {
+        return LookupHash(hash, preimage, test_data->ripemd160_preimages);
+    }
+    miniscript::Availability SatHASH256(const std::vector<unsigned char>& hash, std::vector<unsigned char>& preimage) const {
+        return LookupHash(hash, preimage, test_data->hash256_preimages);
+    }
+    miniscript::Availability SatHASH160(const std::vector<unsigned char>& hash, std::vector<unsigned char>& preimage) const {
+        return LookupHash(hash, preimage, test_data->hash160_preimages);
+    }
+};
+
+//! Context to check a satisfaction against the pre-computed data.
+struct CheckerContext: BaseSignatureChecker {
+    TestData *test_data;
+
+    // Signature checker methods. Checks the right dummy signature is used. Always assumes timelocks are
+    // correct.
+    bool CheckECDSASignature(const std::vector<unsigned char>& sig, const std::vector<unsigned char>& vchPubKey,
+                             const CScript& scriptCode, SigVersion sigversion) const override
+    {
+        const CPubKey key{vchPubKey};
+        const auto it = test_data->dummy_sigs.find(key);
+        if (it == test_data->dummy_sigs.end()) return false;
+        return it->second == sig;
+    }
+    bool CheckLockTime(const CScriptNum& nLockTime) const override { return true; }
+    bool CheckSequence(const CScriptNum& nSequence) const override { return true; }
+};
+
+// The various contexts
+TestData TEST_DATA;
+ParserContext PARSER_CTX;
+SatisfierContext SATISFIER_CTX;
+CheckerContext CHECKER_CTX;
+// A dummy scriptsig to pass to VerifyScript (we always use Segwit v0).
+const CScript DUMMY_SCRIPTSIG;
+
+using Fragment = miniscript::Fragment;
+using NodeRef = miniscript::NodeRef<CPubKey>;
+using miniscript::operator"" _mst;
+
+//! Construct a miniscript node as a shared_ptr.
+template<typename... Args> NodeRef MakeNodeRef(Args&&... args) { return miniscript::MakeNodeRef<CPubKey>(std::forward<Args>(args)...); }
+
+/** Information about a yet to be constructed Miniscript node. */
+struct NodeInfo {
+    //! The type of this node
+    Fragment fragment;
+    //! Number of subs of this node
+    uint8_t n_subs;
+    //! The timelock value for older() and after(), the threshold value for multi() and thresh()
+    uint32_t k;
+    //! Keys for this node, if it has some
+    std::vector<CPubKey> keys;
+    //! The hash value for this node, if it has one
+    std::vector<unsigned char> hash;
+
+    NodeInfo(Fragment frag): fragment(frag), n_subs(0), k(0) {}
+    NodeInfo(Fragment frag, CPubKey key): fragment(frag), n_subs(0), k(0), keys({key}) {}
+    NodeInfo(Fragment frag, uint32_t _k): fragment(frag), n_subs(0), k(_k) {}
+    NodeInfo(Fragment frag, std::vector<unsigned char> h): fragment(frag), n_subs(0), k(0), hash(std::move(h)) {}
+    NodeInfo(Fragment frag, uint8_t subs): fragment(frag), n_subs(subs), k(0) {}
+    NodeInfo(Fragment frag, uint32_t _k, uint8_t subs): fragment(frag), n_subs(subs), k(_k) {}
+    NodeInfo(Fragment frag, uint32_t _k, std::vector<CPubKey> _keys): fragment(frag), n_subs(0), k(_k), keys(std::move(_keys)) {}
+};
+
+std::set<std::pair<Fragment, miniscript::Type>> types;
+
+/** Pick an index in a collection from a single byte in the fuzzer's output. */
+template<typename T, typename A>
+T ConsumeIndex(FuzzedDataProvider& provider, A& col) {
+    const uint8_t i = provider.ConsumeIntegral<uint8_t>();
+    return col[i];
+}
+
+CPubKey ConsumePubKey(FuzzedDataProvider& provider) {
+    return ConsumeIndex<CPubKey>(provider, TEST_DATA.dummy_keys);
+}
+
+std::vector<unsigned char> ConsumeSha256(FuzzedDataProvider& provider) {
+    return ConsumeIndex<std::vector<unsigned char>>(provider, TEST_DATA.sha256);
+}
+
+std::vector<unsigned char> ConsumeHash256(FuzzedDataProvider& provider) {
+    return ConsumeIndex<std::vector<unsigned char>>(provider, TEST_DATA.hash256);
+}
+
+std::vector<unsigned char> ConsumeRipemd160(FuzzedDataProvider& provider) {
+    return ConsumeIndex<std::vector<unsigned char>>(provider, TEST_DATA.ripemd160);
+}
+
+std::vector<unsigned char> ConsumeHash160(FuzzedDataProvider& provider) {
+    return ConsumeIndex<std::vector<unsigned char>>(provider, TEST_DATA.hash160);
+}
+
+std::optional<uint32_t> ConsumeTimeLock(FuzzedDataProvider& provider) {
+    const uint32_t k = provider.ConsumeIntegral<uint32_t>();
+    if (k == 0 || k >= 0x80000000) return {};
+    return k;
+}
+
+/**
+ * Consume a Miniscript node from the fuzzer's output.
+ *
+ * This defines a very basic binary encoding for a Miniscript node:
+ *  - The first byte sets the type of the fragment. 0, 1 and all non-leaf fragments buth thresh() are single
+ *    byte.
+ *  - For the other leaf fragments, the following bytes depend on their type.
+ *    - For older() and after(), the next 4 bytes define the timelock value.
+ *    - For pk_k(), pk_h(), and all hashes, the next byte defines the index of the value in the test data.
+ *    - For multi(), the next 2 bytes define respectively the threshold and the number of keys. Then as many
+ *      bytes as the number of keys define the index of each key in the test data.
+ *    - For thresh(), the next byte defines the threshold value and the following one the number of subs.
+ */
+std::optional<NodeInfo> ConsumeNode(FuzzedDataProvider& provider) {
+    switch (provider.ConsumeIntegral<uint8_t>()) {
+        case 0: return NodeInfo(Fragment::JUST_0);
+        case 1: return NodeInfo(Fragment::JUST_1);
+        case 2: return NodeInfo(Fragment::PK_K, ConsumePubKey(provider));
+        case 3: return NodeInfo(Fragment::PK_H, ConsumePubKey(provider));
+        case 4: {
+            const auto k = ConsumeTimeLock(provider);
+            return k ? NodeInfo(Fragment::OLDER, *k) : std::optional<NodeInfo>{};
+        }
+        case 5: {
+            const auto k = ConsumeTimeLock(provider);
+            return k ? NodeInfo(Fragment::AFTER, *k) : std::optional<NodeInfo>{};
+        }
+        case 6: return NodeInfo(Fragment::SHA256, ConsumeSha256(provider));
+        case 7: return NodeInfo(Fragment::HASH256, ConsumeHash256(provider));
+        case 8: return NodeInfo(Fragment::RIPEMD160, ConsumeRipemd160(provider));
+        case 9: return NodeInfo(Fragment::HASH160, ConsumeHash160(provider));
+        case 10: {
+            const auto k = provider.ConsumeIntegral<uint8_t>();
+            const auto n_keys = provider.ConsumeIntegral<uint8_t>();
+            if (n_keys > 20 || k == 0 || k > n_keys) return {};
+            std::vector<CPubKey> keys{n_keys};
+            for (auto& key: keys) key = ConsumePubKey(provider);
+            return NodeInfo(Fragment::MULTI, k, keys);
+        }
+        case 11: return NodeInfo(Fragment::ANDOR, uint8_t{3});
+        case 12: return NodeInfo(Fragment::AND_V, uint8_t{2});
+        case 13: return NodeInfo(Fragment::AND_B, uint8_t{2});
+        case 15: return NodeInfo(Fragment::OR_B, uint8_t{2});
+        case 16: return NodeInfo(Fragment::OR_C, uint8_t{2});
+        case 17: return NodeInfo(Fragment::OR_D, uint8_t{2});
+        case 18: return NodeInfo(Fragment::OR_I, uint8_t{2});
+        case 19: {
+            auto k = provider.ConsumeIntegral<uint8_t>();
+            auto n_subs = provider.ConsumeIntegral<uint8_t>();
+            if (k == 0 || k > n_subs) return {};
+            return NodeInfo(Fragment::THRESH, k, n_subs);
+        }
+        case 20: return NodeInfo(Fragment::WRAP_A, uint8_t{1});
+        case 21: return NodeInfo(Fragment::WRAP_S, uint8_t{1});
+        case 22: return NodeInfo(Fragment::WRAP_C, uint8_t{1});
+        case 23: return NodeInfo(Fragment::WRAP_D, uint8_t{1});
+        case 24: return NodeInfo(Fragment::WRAP_V, uint8_t{1});
+        case 25: return NodeInfo(Fragment::WRAP_J, uint8_t{1});
+        case 26: return NodeInfo(Fragment::WRAP_N, uint8_t{1});
+        default: return {};
+    }
+
+    assert(false);
+    return {};
+}
+
+/**
+ * Generate a Miniscript node based on the fuzzer's input.
+ */
+NodeRef GenNode(FuzzedDataProvider& provider) {
+    /** A stack of miniscript Nodes being built up. */
+    std::vector<NodeRef> stack;
+    /** The queue of instructions. */
+    std::vector<std::optional<NodeInfo>> todo{{}};
+
+    while (!todo.empty()) {
+        // The expected type we have to construct.
+        if (!todo.back()) {
+            // Fragment/children have not been decided yet. Decide them.
+            auto node_info = ConsumeNode(provider);
+            uint8_t n_subs = node_info->n_subs;
+            if (!node_info) return {};
+            todo.back() = std::move(node_info);
+            for (uint8_t i = 0; i < n_subs; i++) todo.push_back({});
+        } else {
+            // The back of todo has nodetype and number of children decided, and
+            // those children have been constructed at the back of stack. Pop
+            // that entry off todo, and use it to construct a new NodeRef on
+            // stack.
+            const NodeInfo& info = *todo.back();
+            // Gather children from the back of stack.
+            std::vector<NodeRef> sub;
+            sub.reserve(info.n_subs);
+            for (size_t i = 0; i < info.n_subs; ++i) {
+                sub.push_back(std::move(*(stack.end() - info.n_subs + i)));
+            }
+            stack.erase(stack.end() - info.n_subs, stack.end());
+            // Construct new NodeRef.
+            NodeRef node;
+            if (info.keys.empty()) {
+                node = MakeNodeRef(info.fragment, std::move(sub), std::move(info.hash), info.k);
+            } else {
+                assert(sub.empty());
+                assert(info.hash.empty());
+                node = MakeNodeRef(info.fragment, std::move(info.keys), info.k);
+            }
+            // Verify acceptability.
+            if (!node || !node->IsValid()) return {};
+            // Move it to the stack.
+            stack.push_back(std::move(node));
+            todo.pop_back();
+        }
+    }
+    assert(stack.size() == 1);
+    return std::move(stack[0]);
+}
+
+//! Pre-compute the test data and point the various contexts to it.
+void initialize_miniscript_random() {
+    ECC_Start();
+    TEST_DATA.Init();
+    PARSER_CTX.test_data = &TEST_DATA;
+    SATISFIER_CTX.test_data = &TEST_DATA;
+    CHECKER_CTX.test_data = &TEST_DATA;
+}
+
+FUZZ_TARGET_INIT(miniscript_random, initialize_miniscript_random)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    // Generate a top-level node
+    const auto node = GenNode(fuzzed_data_provider);
+    if (!node || !node->IsValidTopLevel()) return;
+
+    // Check roundtrip to Script, and consistency between script size estimation and real size
+    const auto script = node->ToScript(PARSER_CTX);
+    assert(node->ScriptSize() == script.size());
+    auto decoded = miniscript::FromScript(script, PARSER_CTX);
+    assert(decoded);
+    // Note we can't use *decoded == *node because the miniscript representation may differ, so we check that:
+    // - The script corresponding to that decoded form matchs exactly
+    // - The type matches exactly
+    assert(decoded->ToScript(PARSER_CTX) == script);
+    assert(decoded->GetType() == node->GetType());
+
+    // Check consistency of "x" property with the script (relying on the fact that no
+    // top-level scripts end with a hash or key push, whose last byte could match these opcodes).
+    bool ends_in_verify = !(node->GetType() << "x"_mst);
+    assert(ends_in_verify == (script.back() == OP_CHECKSIG || script.back() == OP_CHECKMULTISIG || script.back() == OP_EQUAL));
+
+    // Check that it roundtrips to text representation
+    std::string str;
+    assert(node->ToString(PARSER_CTX, str));
+    auto parsed = miniscript::FromString(str, PARSER_CTX);
+    assert(parsed);
+    assert(*parsed == *node);
+
+    // Check both malleable and non-malleable satisfaction. Note that we only assert the produced witness
+    // is valid if the Miniscript was sane, as otherwise it could overflow the limits.
+    CScriptWitness witness;
+    const CScript script_pubkey = CScript() << OP_0 << WitnessV0ScriptHash(script);
+    const bool mal_success = node->Satisfy(SATISFIER_CTX, witness.stack, false) == miniscript::Availability::YES;
+    if (mal_success && node->IsSaneTopLevel()) {
+        witness.stack.push_back(std::vector<unsigned char>(script.begin(), script.end()));
+        assert(VerifyScript(DUMMY_SCRIPTSIG, script_pubkey, &witness, STANDARD_SCRIPT_VERIFY_FLAGS, CHECKER_CTX));
+    }
+    witness.stack.clear();
+    const bool nonmal_success = node->Satisfy(SATISFIER_CTX, witness.stack, true) == miniscript::Availability::YES;
+    if (nonmal_success && node->IsSaneTopLevel()) {
+        witness.stack.push_back(std::vector<unsigned char>(script.begin(), script.end()));
+        assert(VerifyScript(DUMMY_SCRIPTSIG, script_pubkey, &witness, STANDARD_SCRIPT_VERIFY_FLAGS, CHECKER_CTX));
+    }
+    // If a nonmalleable solution exists, a solution whatsoever must also exist.
+    assert(mal_success >= nonmal_success);
+    // If a miniscript is nonmalleable and needs a signature, and a solution exists, a non-malleable solution must also exist.
+    if (node->IsNonMalleable() && node->NeedsSignature()) assert(nonmal_success == mal_success);
+}

--- a/bitcoin/test/miniscript_tests.cpp
+++ b/bitcoin/test/miniscript_tests.cpp
@@ -503,12 +503,11 @@ void Test(const std::string& ms, const std::string& hexscript, int mode, int ops
         auto inferred_miniscript = miniscript::FromScript(computed_script, CONVERTER);
         BOOST_CHECK_MESSAGE(inferred_miniscript, "Cannot infer miniscript from script: " + ms);
         BOOST_CHECK_MESSAGE(inferred_miniscript->ToScript(CONVERTER) == computed_script, "Roundtrip failure: miniscript->script != miniscript->script->miniscript->script: " + ms);
-        if (opslimit != -1) BOOST_CHECK_MESSAGE((int)node->GetOps() == opslimit, "Ops limit mismatch: " + ms + " (" + std::to_string(node->GetOps()) + " vs " + std::to_string(opslimit) + ")");
-        if (stacklimit != -1) BOOST_CHECK_MESSAGE((int)node->GetStackSize() == stacklimit, "Stack limit mismatch: " + ms + " (" + std::to_string(node->GetStackSize()) + " vs " + std::to_string(stacklimit) + ")");
+        if (opslimit != -1) BOOST_CHECK_MESSAGE((int)node->GetOps() == opslimit, "Ops limit mismatch: " << ms << " (" << node->GetOps() << " vs " << opslimit << ")");
+        if (stacklimit != -1) BOOST_CHECK_MESSAGE((int)node->GetStackSize() == stacklimit, "Stack limit mismatch: " << ms << " (" << node->GetStackSize() << " vs " << stacklimit << ")");
         TestSatisfy(ms, node);
     }
 }
-
 } // namespace
 
 BOOST_FIXTURE_TEST_SUITE(miniscript_tests, BasicTestingSetup)

--- a/bitcoin/test/miniscript_tests.cpp
+++ b/bitcoin/test/miniscript_tests.cpp
@@ -113,9 +113,6 @@ typedef std::pair<ChallengeType, uint32_t> Challenge;
 struct KeyConverter {
     typedef CPubKey Key;
 
-    //! Public keys in text form are their usual hex notation (no xpubs, ...).
-    bool ToString(const CPubKey& key, std::string& ret) const { ret = HexStr(key); return true; }
-
     //! Convert a public key to bytes.
     std::vector<unsigned char> ToPKBytes(const CPubKey& key) const { return {key.begin(), key.end()}; }
 
@@ -236,7 +233,6 @@ const KeyConverter CONVERTER{};
 // Helper types and functions that use miniscript instantiated for CPubKey.
 using NodeType = miniscript::NodeType;
 using NodeRef = miniscript::NodeRef<CPubKey>;
-template<typename... Args> NodeRef MakeNodeRef(Args&&... args) { return miniscript::MakeNodeRef<CPubKey>(std::forward<Args>(args)...); }
 using miniscript::operator"" _mst;
 
 //! Determine whether a Miniscript node is satisfiable at all (and thus isn't equivalent to just "false").
@@ -265,135 +261,6 @@ bool Satisfiable(const NodeRef& ref) {
     assert(false);
     return false;
 }
-
-NodeRef GenNode(miniscript::Type typ, int complexity);
-
-//! Generate a random valid miniscript node of the given type and complexity.
-NodeRef RandomNode(miniscript::Type typ, int complexity) {
-    assert(complexity > 0);
-    NodeRef ret;
-    do {
-        ret = GenNode(typ, complexity);
-    } while (!ret || !ret->IsValid() || !(ret->GetType() << typ));
-    return ret;
-}
-
-//! Generate a vector of valid miniscript nodes of the given types, and a specified complexity of their sum.
-std::vector<NodeRef> MultiNode(int complexity, const std::vector<miniscript::Type>& types)
-{
-    int nodes = types.size();
-    assert(complexity >= nodes);
-    std::vector<int> subcomplex(nodes, 1);
-    if (nodes == 1) {
-        subcomplex[0] = complexity;
-    } else {
-        // This is a silly inefficient way to construct a multinomial distribution.
-        for (int i = 0; i < complexity - nodes; ++i) {
-            subcomplex[InsecureRandRange(nodes)]++;
-        }
-    }
-    std::vector<NodeRef> subs;
-    for (int i = 0; i < nodes; ++i) {
-        subs.push_back(RandomNode(types[i], subcomplex[i]));
-    }
-    return subs;
-}
-
-//! Generate a random (but occasionally invalid) miniscript node of the given type and complexity.
-NodeRef GenNode(miniscript::Type typ, int complexity) {
-    if (typ << "B"_mst) {
-        // Generate a "B" node.
-        if (complexity == 1) {
-            switch (InsecureRandBits(2)) {
-                case 0: return MakeNodeRef(InsecureRandBool() ? NodeType::JUST_0 : NodeType::JUST_1);
-                case 1: return MakeNodeRef(InsecureRandBool() ? NodeType::OLDER : NodeType::AFTER, 1 + InsecureRandRange((1ULL << (1 + InsecureRandRange(31))) - 1));
-                case 2: {
-                    int hashtype = InsecureRandBits(2);
-                    int index = InsecureRandRange(255);
-                    switch (hashtype) {
-                        case 0: return MakeNodeRef(NodeType::SHA256, g_testdata->sha256[index]);
-                        case 1: return MakeNodeRef(NodeType::RIPEMD160, g_testdata->ripemd160[index]);
-                        case 2: return MakeNodeRef(NodeType::HASH256, g_testdata->hash256[index]);
-                        case 3: return MakeNodeRef(NodeType::HASH160, g_testdata->hash160[index]);
-                    }
-                    break;
-                }
-                case 3: return MakeNodeRef(NodeType::WRAP_C, MultiNode(complexity, Vector("K"_mst)));
-            }
-            assert(false);
-        }
-        switch (InsecureRandRange(7 + (complexity >= 3) * 7 + (complexity >= 4) * 2)) {
-            // Complexity >= 2
-            case 0: return MakeNodeRef(NodeType::WRAP_C, MultiNode(complexity, Vector("K"_mst)));
-            case 1: return MakeNodeRef(NodeType::WRAP_D, MultiNode(complexity - 1, Vector("V"_mst)));
-            case 2: return MakeNodeRef(NodeType::WRAP_J, MultiNode(complexity - 1, Vector("B"_mst)));
-            case 3: return MakeNodeRef(NodeType::WRAP_N, MultiNode(complexity - 1, Vector("B"_mst)));
-            case 4: return MakeNodeRef(NodeType::OR_I, Cat(MultiNode(complexity - 1, Vector("B"_mst)), Vector(MakeNodeRef(NodeType::JUST_0))));
-            case 5: return MakeNodeRef(NodeType::OR_I, Cat(Vector(MakeNodeRef(NodeType::JUST_0)), MultiNode(complexity - 1, Vector("B"_mst))));
-            case 6: return MakeNodeRef(NodeType::AND_V, Cat(MultiNode(complexity - 1, Vector("V"_mst)), Vector(MakeNodeRef(NodeType::JUST_1))));
-            // Complexity >= 3
-            case 7: return MakeNodeRef(NodeType::AND_V, MultiNode(complexity - 1, Vector("V"_mst, "B"_mst)));
-            case 8: return MakeNodeRef(NodeType::ANDOR, Cat(MultiNode(complexity - 1, Vector("B"_mst, "B"_mst)), Vector(MakeNodeRef(NodeType::JUST_0))));
-            case 9: return MakeNodeRef(NodeType::AND_B, MultiNode(complexity - 1, Vector("B"_mst, "W"_mst)));
-            case 10: return MakeNodeRef(NodeType::OR_B, MultiNode(complexity - 1, Vector("B"_mst, "W"_mst)));
-            case 11: return MakeNodeRef(NodeType::OR_D, MultiNode(complexity - 1, Vector("B"_mst, "B"_mst)));
-            case 12: return MakeNodeRef(NodeType::OR_I, MultiNode(complexity - 1, Vector("B"_mst, "B"_mst)));
-            case 13: {
-                if (complexity != 3) return {};
-                int nkeys = 1 + (InsecureRandRange(15) * InsecureRandRange(25)) / 17;
-                int sigs = 1 + InsecureRandRange(nkeys);
-                std::vector<CPubKey> keys;
-                for (int i = 0; i < nkeys; ++i) keys.push_back(g_testdata->pubkeys[InsecureRandRange(255)]);
-                return MakeNodeRef(NodeType::MULTI, std::move(keys), sigs);
-            }
-            // Complexity >= 4
-            case 14: return MakeNodeRef(NodeType::ANDOR, MultiNode(complexity - 1, Vector("B"_mst, "B"_mst, "B"_mst)));
-            case 15: {
-                int args = 3 + InsecureRandRange(std::min(3, complexity - 3));
-                int sats = 2 + InsecureRandRange(args - 2);
-                return MakeNodeRef(NodeType::THRESH, MultiNode(complexity - 1, Cat(Vector("B"_mst), std::vector<miniscript::Type>(args - 1, "W"_mst))), sats);
-            }
-        }
-    } else if (typ << "V"_mst) {
-        // Generate a "V" node.
-        switch (InsecureRandRange(1 + (complexity >= 3) * 3 + (complexity >= 4))) {
-            // Complexity >= 1
-            case 0: return MakeNodeRef(NodeType::WRAP_V, MultiNode(complexity, Vector("B"_mst)));
-            // Complexity >= 3
-            case 1: return MakeNodeRef(NodeType::AND_V, MultiNode(complexity - 1, Vector("V"_mst, "V"_mst)));
-            case 2: return MakeNodeRef(NodeType::OR_C, MultiNode(complexity - 1, Vector("B"_mst, "V"_mst)));
-            case 3: return MakeNodeRef(NodeType::OR_I, MultiNode(complexity - 1, Vector("V"_mst, "V"_mst)));
-            // Complexity >= 4
-            case 4: return MakeNodeRef(NodeType::ANDOR, MultiNode(complexity - 1, Vector("B"_mst, "V"_mst, "V"_mst)));
-        }
-    } else if (typ << "W"_mst) {
-        // Generate a "W" node by wrapping a "B" node.
-        auto sub = RandomNode("B"_mst, complexity);
-        if (sub->GetType() << "o"_mst) {
-            if (InsecureRandBool()) return MakeNodeRef(NodeType::WRAP_S, Vector(std::move(sub)));
-        }
-        return MakeNodeRef(NodeType::WRAP_A, Vector(std::move(sub)));
-    } else if (typ << "K"_mst) {
-        // Generate a "K" node.
-        if (complexity == 1 || complexity == 2) {
-            if (InsecureRandBool()) {
-                return MakeNodeRef(NodeType::PK_K, Vector(g_testdata->pubkeys[InsecureRandRange(255)]));
-            } else {
-                return MakeNodeRef(NodeType::PK_H, Vector(g_testdata->pubkeys[InsecureRandRange(255)]));
-            }
-        }
-        switch (InsecureRandRange(2 + (complexity >= 4))) {
-            // Complexity >= 3
-            case 0: return MakeNodeRef(NodeType::AND_V, MultiNode(complexity - 1, Vector("V"_mst, "K"_mst)));
-            case 1: return MakeNodeRef(NodeType::OR_I, MultiNode(complexity - 1, Vector("K"_mst, "K"_mst)));
-            // Complexity >= 4
-            case 2: return MakeNodeRef(NodeType::ANDOR, MultiNode(complexity - 1, Vector("B"_mst, "K"_mst, "K"_mst)));
-        }
-    }
-    assert(false);
-    return {};
-}
-
 
 /** Compute all challenges (pubkeys, hashes, timelocks) that occur in a given Miniscript. */
 std::set<Challenge> FindChallenges(const NodeRef& ref) {
@@ -635,38 +502,6 @@ BOOST_AUTO_TEST_CASE(fixed_tests)
     // This is actually non-malleable in practice, but we cannot detect it in type system. See above rationale
     Test("thresh(1,c:pk_k(03d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65),altv:after(1000000000),altv:after(100))", "?", TESTMODE_VALID); // thresh with k = 1
 
-
-    g_testdata.reset();
-}
-
-BOOST_AUTO_TEST_CASE(random_tests)
-{
-    // Initialize precomputed data.
-    g_testdata.reset(new TestData());
-
-    for (int i = 0; i < 1000; ++i) {
-        bool safe = InsecureRandRange(20) == 0; // In 5% of the cases, generate safe top-level expressions.
-        // Generate a random B (or Bms) node of variable complexity, which should be valid as a top-level expression.
-        auto node = RandomNode(safe ? "Bms"_mst : "B"_mst, 1 + InsecureRandRange(90));
-        BOOST_CHECK(node && node->IsValid() && node->IsValidTopLevel());
-        auto script = node->ToScript(CONVERTER);
-        BOOST_CHECK(node->ScriptSize() == script.size()); // Check consistency between script size estimation and real size
-        // Check consistency of "x" property with the script (relying on the fact that no top-level scripts end with a hash or key push, whose last byte could match these opcodes).
-        bool ends_in_verify = !(node->GetType() << "x"_mst);
-        BOOST_CHECK(ends_in_verify == (script.back() == OP_CHECKSIG || script.back() == OP_CHECKMULTISIG || script.back() == OP_EQUAL));
-        std::string str;
-        BOOST_CHECK(node->ToString(CONVERTER, str)); // Check that we can convert to text
-        auto parsed = miniscript::FromString(str, CONVERTER);
-        BOOST_CHECK(parsed); // Check that we can convert back
-        BOOST_CHECK(*parsed == *node); // Check that it matches the original
-        auto decoded = miniscript::FromScript(script, CONVERTER);
-        BOOST_CHECK(decoded); // Check that we can decode the miniscript back from the script.
-        // Check that it matches the original (we can't use *decoded == *node because the miniscript representation may differ)
-        BOOST_CHECK(decoded->ToScript(CONVERTER) == script); // The script corresponding to that decoded form must match exactly.
-        BOOST_CHECK(decoded->GetType() == node->GetType()); // The type also has to match exactly.
-        // Random satisfaction tests.
-        TestSatisfy(str, node);
-    }
 
     g_testdata.reset();
 }

--- a/bitcoin/util/string.h
+++ b/bitcoin/util/string.h
@@ -1,0 +1,106 @@
+// Copyright (c) 2019-2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_STRING_H
+#define BITCOIN_UTIL_STRING_H
+
+#include <attributes.h>
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <locale>
+#include <sstream>
+#include <string>
+#include <vector>
+
+[[nodiscard]] inline std::string TrimString(const std::string& str, const std::string& pattern = " \f\n\r\t\v")
+{
+    std::string::size_type front = str.find_first_not_of(pattern);
+    if (front == std::string::npos) {
+        return std::string();
+    }
+    std::string::size_type end = str.find_last_not_of(pattern);
+    return str.substr(front, end - front + 1);
+}
+
+[[nodiscard]] inline std::string RemovePrefix(const std::string& str, const std::string& prefix)
+{
+    if (str.substr(0, prefix.size()) == prefix) {
+        return str.substr(prefix.size());
+    }
+    return str;
+}
+
+/**
+ * Join a list of items
+ *
+ * @param list       The list to join
+ * @param separator  The separator
+ * @param unary_op   Apply this operator to each item in the list
+ */
+template <typename T, typename BaseType, typename UnaryOp>
+auto Join(const std::vector<T>& list, const BaseType& separator, UnaryOp unary_op)
+    -> decltype(unary_op(list.at(0)))
+{
+    decltype(unary_op(list.at(0))) ret;
+    for (size_t i = 0; i < list.size(); ++i) {
+        if (i > 0) ret += separator;
+        ret += unary_op(list.at(i));
+    }
+    return ret;
+}
+
+template <typename T>
+T Join(const std::vector<T>& list, const T& separator)
+{
+    return Join(list, separator, [](const T& i) { return i; });
+}
+
+// Explicit overload needed for c_str arguments, which would otherwise cause a substitution failure in the template above.
+inline std::string Join(const std::vector<std::string>& list, const std::string& separator)
+{
+    return Join<std::string>(list, separator);
+}
+
+/**
+ * Create an unordered multi-line list of items.
+ */
+inline std::string MakeUnorderedList(const std::vector<std::string>& items)
+{
+    return Join(items, "\n", [](const std::string& item) { return "- " + item; });
+}
+
+/**
+ * Check if a string does not contain any embedded NUL (\0) characters
+ */
+[[nodiscard]] inline bool ValidAsCString(const std::string& str) noexcept
+{
+    return str.size() == strlen(str.c_str());
+}
+
+/**
+ * Locale-independent version of std::to_string
+ */
+template <typename T>
+std::string ToString(const T& t)
+{
+    std::ostringstream oss;
+    oss.imbue(std::locale::classic());
+    oss << t;
+    return oss.str();
+}
+
+/**
+ * Check whether a container begins with the given prefix.
+ */
+template <typename T1, size_t PREFIX_LEN>
+[[nodiscard]] inline bool HasPrefix(const T1& obj,
+                                const std::array<uint8_t, PREFIX_LEN>& prefix)
+{
+    return obj.size() >= PREFIX_LEN &&
+           std::equal(std::begin(prefix), std::end(prefix), std::begin(obj));
+}
+
+#endif // BITCOIN_UTIL_STRING_H


### PR DESCRIPTION
Based on #99 .

This is the "dumb" version of the Miniscript node generation from fuzzer
input. It defines a strict binary encoding and will always generate a
node defined from the encoding without "helping" to create valid nodes.
It will cut through as soon as it encounters an invalid fragment so
hopefully the fuzzer can tend to learn the encoding and generate valid
nodes with a higher probability.
    
On a valid generated node a number of invariants are checked, especially
 around the satisfactions and testing them against the Script
 interpreter.