### PR TITLE
Remove the `u` property from `d`

### DIFF
--- a/bitcoin/script/miniscript.cpp
+++ b/bitcoin/script/miniscript.cpp
@@ -114,7 +114,8 @@ Type ComputeType(Fragment fragment, Type x, Type y, Type z, const std::vector<Ty
             "e"_mst.If(x << "f"_mst) | // e=f_x
             (x & "ghijk"_mst) | // g=g_x, h=h_x, i=i_x, j=j_x, k=k_x
             (x & "ms"_mst) | // m=m_x, s=s_x
-            "nudx"_mst; // n, u, d, x
+            // NOTE: 'd:' is not 'u' under P2WSH as MINIMALIF is only a policy rule there.
+            "ndx"_mst; // n, d, x
         case Fragment::WRAP_V: return
             "V"_mst.If(x << "B"_mst) | // V=B_x
             (x & "ghijk"_mst) | // g=g_x, h=h_x, i=i_x, j=j_x, k=k_x

--- a/bitcoin/test/miniscript_tests.cpp
+++ b/bitcoin/test/miniscript_tests.cpp
@@ -490,6 +490,15 @@ BOOST_AUTO_TEST_CASE(fixed_tests)
     BOOST_CHECK(ms_multi);
     BOOST_CHECK_EQUAL(ms_multi->GetOps(), 4); // 3 pubkeys + CMS
     BOOST_CHECK_EQUAL(ms_multi->GetStackSize(), 3); // 1 sig + dummy elem + script push
+    // The 'd:' wrapper leaves on the stack what was DUP'ed at the beginning of its execution.
+    // Since it contains an OP_IF just after on the same element, we can make sure that the element
+    // in question must be OP_1 if OP_IF enforces that its argument must only be OP_1 or the empty
+    // vector (since otherwise the execution would immediately fail). This is the MINIMALIF rule.
+    // Unfortunately, this rule is consensus for Taproot but only policy for P2WSH. Therefore we can't
+    // (for now) have 'd:' be 'u'. This tests we can't use a 'd:' wrapper for a thresh, which requires
+    // its subs to all be 'u' (taken from https://github.com/rust-bitcoin/rust-miniscript/discussions/341).
+    const auto ms_minimalif = miniscript::FromString("thresh(3,c:pk_k(03d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65),sc:pk_k(03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556),sc:pk_k(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798),sdv:older(32))", CONVERTER);
+    BOOST_CHECK(!ms_minimalif);
 
     // Timelock tests
     Test("after(100)", "?", TESTMODE_VALID | TESTMODE_NONMAL); // only heightlock

--- a/index.html
+++ b/index.html
@@ -402,7 +402,7 @@ This tables lists the correctness requirements for each of the Miniscript expres
 <tr><td><code>a:X</code></td><td><em>X</em> is B</td><td>W</td><td>d=d<sub>X</sub>; u=u<sub>X</sub></td></tr>
 <tr><td><code>s:X</code></td><td><em>X</em> is Bo</td><td>W</td><td>d=d<sub>X</sub>; u=u<sub>X</sub></td></tr>
 <tr><td><code>c:X</code></td><td><em>X</em> is K</td><td>B</td><td>o=o<sub>X</sub>; n=n<sub>X</sub>; d=d<sub>X</sub>; u</td></tr>
-<tr><td><code>d:X</code></td><td><em>X</em> is Vz</td><td>B</td><td>o; n; d; u</td></tr>
+<tr><td><code>d:X</code></td><td><em>X</em> is Vz</td><td>B</td><td>o; n; d</td></tr>
 <tr><td><code>v:X</code></td><td><em>X</em> is B</td><td>V</td><td>z=z<sub>X</sub>; o=o<sub>X</sub>; n=n<sub>X</sub></td></tr>
 <tr><td><code>j:X</code></td><td><em>X</em> is Bn</td><td>B</td><td>o=o<sub>X</sub>; n; d; u=u<sub>X</sub></td></tr>
 <tr><td><code>n:X</code></td><td><em>X</em> is B</td><td>B</td><td>z=z<sub>X</sub>; o=o<sub>X</sub>; n=n<sub>X</sub>; d=d<sub>X</sub>; u</td></tr>


### PR DESCRIPTION
As reported by Andrew on IRC. I think it's the cleanest simple fix. It will come at the cost of a few needless `0NOTEQUAL`, but better have this than miners being able to bypass a `thresh` :sweat_smile:.

I checked the other fragments and i don't think anything else is affected. I checked the compiler and i don't think any modification is needed as it doesn't appear to rely on the `u` property of `d:`?