### PR TITLE
fuzz: assert(false) at switch default case

### DIFF
--- a/bitcoin/test/fuzz/miniscript.cpp
+++ b/bitcoin/test/fuzz/miniscript.cpp
@@ -671,6 +671,8 @@ std::optional<NodeInfo> ConsumeNodeSmart(FuzzedDataProvider& provider, Type type
             return {{std::move(subs), frag, k}};
         }
     }
+
+    assert(false);
 }
 
 /**


### PR DESCRIPTION
This crashes loudly if missed when a new enum variant is added, and quiets a build warning.