### PR TITLE
website: small fixup to 'd:' satisfaction

### DIFF
--- a/index.html
+++ b/index.html
@@ -492,7 +492,7 @@ are listed for completeness, but marked in <span class="text-muted">[grey]</span
 <tr><td><code>a:<em>X</em></code></td><td>dsat(<em>X</em>)</td><td>sat(<em>X</em>)</td></tr>
 <tr><td><code>s:<em>X</em></code></td><td>dsat(<em>X</em>)</td><td>sat(<em>X</em>)</td></tr>
 <tr><td><code>c:<em>X</em></code></td><td>dsat(<em>X</em>)</td><td>sat(<em>X</em>)</td></tr>
-<tr><td><code>d:<em>X</em></code></td><td>0</td><td>1</td></tr>
+<tr><td><code>d:<em>X</em></code></td><td>0</td><td>sat(<em>X</em>) 1</td></tr>
 <tr><td><code>v:<em>X</em></code></td><td>-</td><td>sat(<em>X</em>)</td></tr>
 <tr><td><code>j:<em>X</em></code></td><td>0; <span class="text-muted">[dsat(<em>X</em>) (if nonzero top stack)]</span></td><td>sat(<em>X</em>)</td></tr>
 <tr><td><code>n:<em>X</em></code></td><td>dsat(<em>X</em>)</td><td>sat(<em>X</em>)</td></tr>


### PR DESCRIPTION
It's not enough to give 1 to satisfy 'd:X', you also need to actually
satisfy the sub fragment.