### PR TITLE
Fixes #126 - hash160/ripemd160 were generating incorrect ASM

### DIFF
--- a/compiler.cpp
+++ b/compiler.cpp
@@ -846,10 +846,12 @@ std::string Disassembler(CScript::const_iterator& it, CScript::const_iterator en
         }
         if (data.size() == 20) {
             if (data == std::vector<unsigned char>(20, 0x99)) {
-                ret += "<h>";
+                ret += "<H>";
             } else if (data[0] == 'P' && data[1] == 'K' && data[2] == 'h') {
                 while (data.size() && data.back() == 0) data.pop_back();
                 ret += "<HASH160(" + std::string((const char*)data.data() + 3, data.size() - 3) + ")>";
+            } else {
+                ret += "<" + HexStr(data.begin(), data.end()) + ">";
             }
         } else if (data.size() == 32 && data == std::vector<unsigned char>(32, 0x88)) {
             ret += "<H>";

--- a/compiler.cpp
+++ b/compiler.cpp
@@ -850,7 +850,7 @@ std::string Disassembler(CScript::const_iterator& it, CScript::const_iterator en
             } else if (data[0] == 'P' && data[1] == 'K' && data[2] == 'h') {
                 while (data.size() && data.back() == 0) data.pop_back();
                 ret += "<HASH160(" + std::string((const char*)data.data() + 3, data.size() - 3) + ")>";
-            } else {
+            } else if (data.size() > 0) {
                 ret += "<" + HexStr(data.begin(), data.end()) + ">";
             }
         } else if (data.size() == 32 && data == std::vector<unsigned char>(32, 0x88)) {

--- a/compiler.cpp
+++ b/compiler.cpp
@@ -850,7 +850,7 @@ std::string Disassembler(CScript::const_iterator& it, CScript::const_iterator en
             } else if (data[0] == 'P' && data[1] == 'K' && data[2] == 'h') {
                 while (data.size() && data.back() == 0) data.pop_back();
                 ret += "<HASH160(" + std::string((const char*)data.data() + 3, data.size() - 3) + ")>";
-            } else if (data.size() > 0) {
+            } else {
                 ret += "<" + HexStr(data.begin(), data.end()) + ">";
             }
         } else if (data.size() == 32 && data == std::vector<unsigned char>(32, 0x88)) {


### PR DESCRIPTION
Fixes #126 

When passing hex values to `ripemd160` and `hash160` as in: `hash160(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)` it will generate correct ASM:

`OP_SIZE <20> OP_EQUALVERIFY OP_RIPEMD160 <aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa> OP_EQUAL`
Not omitting the `<aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa>`

When using the special value `H`, ASM will then produce `<H>` instead of lower case `<h>`.
