### PR TITLE
Link to the upstream rust-miniscript

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@ Miniscript was designed and implemented by Pieter Wuille, Andrew Poelstra, and S
 Links:<ul>
 <li>This <a href="http://bitcoin.sipa.be/miniscript">website</a> and C++ compiler: <a href="https://github.com/sipa/miniscript">[code]</a></li>
 <li>Bitcoin Core compatible C++ implementation: <a href="https://github.com/sipa/miniscript/tree/master/bitcoin/script">[code]</a></li>
-<li>Rust-miniscript implementation: <a href="https://github.com/apoelstra/rust-miniscript">[code]</a></li>
+<li>Rust-miniscript implementation: <a href="https://github.com/rust-bitcoin/rust-miniscript">[code]</a></li>
 <li>Talk about (an early version of) Miniscript at <a href="https://cyber.stanford.edu/sbc19">SBC'19</a>: <a href="https://www.youtube.com/watch?v=XM1lzN4Zfks">[video]</a> <a href="http://diyhpl.us/wiki/transcripts/stanford-blockchain-conference/2019/miniscript/">[transcript]</a> <a href="https://prezi.com/view/KH7AXjnse7glXNoqCxPH/">[slides]</a></li>
 </ul>
 


### PR DESCRIPTION
Hi, I suggest linking to the upstream version of `rust-miniscript `instead of the outdated fork from Andrew Poelstra.