### PR TITLE
fix: key name can be up to 16 characters

### DIFF
--- a/compiler.h
+++ b/compiler.h
@@ -16,7 +16,7 @@ struct CompilerContext {
 
     template<typename I>
     std::optional<Key> FromString(I first, I last) const {
-        if (std::distance(first, last) == 0 || std::distance(first, last) > 17) return {};
+        if (std::distance(first, last) == 0 || std::distance(first, last) > 16) return {};
         return std::string(first, last);
     }
 


### PR DESCRIPTION
In Policy to Miniscript compiler section,

> pk(NAME): Require public key named NAME to sign. NAME can be any string up to 16 characters.

However, it's allowed up to 17 in compiler code. This PR will fix it.